### PR TITLE
[TCFMM-12] Initialize ticks with "infinite" index at origination 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ out/
 
 # Haskell
 .stack-work/
+haskell/test/segmented_cfmm_default.tz
+haskell/test/storage_default.tz

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ LIGO ?= ligo
 # Compile code
 BUILD = $(LIGO) compile-contract --syntax cameligo
 
+# Compile storage
+BUILD_STORAGE = $(LIGO) compile-storage --syntax cameligo
+
 # Where to put build files
 OUT ?= out
 
@@ -16,7 +19,7 @@ TS_OUT ?= typescript
 # Utility function to escape double quotes
 escape_double_quote = $(subst $\",$\\",$(1))
 
-.PHONY: all lib metadata error-codes test typescript clean
+.PHONY: all prepare_lib lib metadata error-codes test typescript clean
 
 # Builds LIGO contract. Arguments:
 #   1: The source file
@@ -30,13 +33,26 @@ define build_ligo
 	$(foreach CVAR,$(3),$(file >>$(TOTAL_FILE),#define $(CVAR)))
 	@echo "#include \"$(notdir $(1))\"" >> $(TOTAL_FILE)
 
-	# ============== Compiling `$(1)` with options `$(3)` ============== #
+	# ============== Compiling Ligo Contract `$(1)` with options `$(3)` ============== #
 	@$(BUILD) $(TOTAL_FILE) main --output-file $(2) || ( rm $(TOTAL_FILE) && exit 1 )
 	@rm $(TOTAL_FILE)
 endef
 
+define build_ligo_storage
+	@mkdir -p $(dir $(2))
+
+	@ #Create a file and put necessary #define pragmas to it first
+	$(eval TOTAL_FILE := $(shell mktemp $(1).total-XXX))
+	$(foreach CVAR,$(3),$(file >>$(TOTAL_FILE),#define $(CVAR)))
+	@echo "#include \"$(notdir $(1))\"" >> $(TOTAL_FILE)
+
+	# ============== Compiling Ligo Storage `$(1)` with options `$(3)` ============== #
+	@$(BUILD_STORAGE) $(TOTAL_FILE) main default_storage --output-file $(2) || ( rm $(TOTAL_FILE) && exit 1 )
+	@rm $(TOTAL_FILE)
+endef
+
 all: \
-	$(OUT)/segmented_cfmm_default.tz
+	$(OUT)/segmented_cfmm_default.tz $(OUT)/storage_default.tz
 
 $(OUT)/segmented_cfmm_default.tz : LIGO_PRAGMAS = DUMMY_PRAGMA1 DUMMY_PRAGMA2
 
@@ -44,7 +60,19 @@ $(OUT)/segmented_cfmm_default.tz : LIGO_PRAGMAS = DUMMY_PRAGMA1 DUMMY_PRAGMA2
 $(OUT)/segmented_cfmm_%.tz: $(shell find ligo -name '*.mligo')
 	$(call build_ligo,ligo/main.mligo,$(OUT)/segmented_cfmm_$*.tz,$(LIGO_PRAGMAS))
 
-lib: all
+
+$(OUT)/storage_default.tz : LIGO_PRAGMAS = DUMMY_PRAGMA1 DUMMY_PRAGMA2
+
+$(OUT)/storage_%.tz: $(shell find ligo -name '*.mligo')
+	$(call build_ligo_storage,ligo/main.mligo,$(OUT)/storage_$*.tz,$(LIGO_PRAGMAS))
+
+prepare_lib: all
+	# ============== Copying ligo sources to haskell lib paths ============== #
+	mkdir -p haskell/test
+	cp $(OUT)/segmented_cfmm_default.tz haskell/test/segmented_cfmm_default.tz
+	cp $(OUT)/storage_default.tz haskell/test/storage_default.tz
+
+lib: prepare_lib
 	$(MAKE) -C haskell build PACKAGE=segmented-cfmm \
 		STACK_DEV_OPTIONS="--fast --ghc-options -Wwarn"
 
@@ -55,7 +83,7 @@ metadata : y_token_symbol = y
 metadata : y_token_name = "Token Y"
 metadata : y_token_decimals = 1
 metadata : output = metadata.json
-metadata: lib all
+metadata: lib
 	$(MAKE) -C haskell exec PACKAGE=segmented-cfmm \
 		EXEC_ARGUMENTS="print-metadata \
 		--x-token-symbol $(x_token_symbol) --x-token-name $(call escape_double_quote,$(x_token_name)) \
@@ -67,18 +95,18 @@ metadata: lib all
 error-codes:
 	stack scripts/generate_error_code.hs
 
-test: all
-	$(MAKE) -C haskell test PACKAGE=segmented-cfmm \
-		SEGMENTED_CFMM_PATH=../$(OUT)/segmented_cfmm_default.tz
+test: prepare_lib
+	$(MAKE) -C haskell test PACKAGE=segmented-cfmm
 
-typescript: all
+typescript: prepare_lib
 	$(MAKE) -C haskell build PACKAGE=segmented-cfmm \
-		STACK_DEV_OPTIONS="--fast --ghc-options -Wwarn" \
-		SEGMENTED_CFMM_PATH=../$(OUT)/segmented_cfmm_default.tz
+		STACK_DEV_OPTIONS="--fast --ghc-options -Wwarn"
 
 	rm -rf $(TS_OUT)/segmented-cfmm/src/generated/*
 	stack exec -- segmented-cfmm generate-typescript --target=$(TS_OUT)/segmented-cfmm/src/generated/
 
 clean:
 	rm -rf $(OUT)
+	rm haskell/test/segmented_cfmm_default.tz
+	rm haskell/test/storage_default.tz
 	$(MAKE) -C haskell clean

--- a/ci.nix
+++ b/ci.nix
@@ -56,8 +56,8 @@ rec {
       {
         packages.segmented-cfmm = {
           preBuild = ''
-            mkdir -p ./haskell/test
-            cp -r ${build-ligo}/* ./haskell/test
+            mkdir -p ./test
+            cp -r ${build-ligo}/* ./test
           '';
         };
       }

--- a/haskell/package.yaml
+++ b/haskell/package.yaml
@@ -13,7 +13,8 @@ extra-doc-files:
 - README.md
 
 extra-source-files:
-- test/segmented_cfmm.tz
+- test/segmented_cfmm_default.tz
+- test/storage_default.tz
 
 description:         Tools and tests for the Segmented CFMM contract.
 

--- a/haskell/segmented-cfmm.cabal
+++ b/haskell/segmented-cfmm.cabal
@@ -14,7 +14,8 @@ license:        MIT
 license-file:   LICENSE
 build-type:     Simple
 extra-source-files:
-    test/segmented_cfmm.tz
+    test/segmented_cfmm_default.tz
+    test/storage_default.tz
 extra-doc-files:
     README.md
 
@@ -77,6 +78,7 @@ test-suite segmented-cfmm-test
   other-modules:
       Test.SegCFMM
       Test.SegCFMM.Contract
+      Test.SegCFMM.Storage
       Test.SegCFMM.Types
       Paths_segmented_cfmm
   hs-source-dirs:

--- a/haskell/test/Test/SegCFMM/Contract.hs
+++ b/haskell/test/Test/SegCFMM/Contract.hs
@@ -1,9 +1,10 @@
 -- SPDX-FileCopyrightText: 2021 Arthur Breitman
 -- SPDX-License-Identifier: LicenseRef-MIT-Arthur-Breitman
 
--- | LIGO version of the contract.
+-- | Module that contains the import of segmented-cfmm contract to be used
+-- in Haskell tests.
 module Test.SegCFMM.Contract
-  ( segCFMMContractLigo
+  ( segCFMMContract
   ) where
 
 import Michelson.Typed
@@ -11,6 +12,6 @@ import Michelson.Typed
 import SegCFMM.Types
 import Util (fetchContract)
 
-segCFMMContractLigo :: Contract (ToT Parameter) (ToT Storage)
-segCFMMContractLigo =
+segCFMMContract :: Contract (ToT Parameter) (ToT Storage)
+segCFMMContract =
  $(fetchContract @(ToT Parameter) @(ToT Storage) "SEGMENTED_CFMM_PATH")

--- a/haskell/test/Test/SegCFMM/Storage.hs
+++ b/haskell/test/Test/SegCFMM/Storage.hs
@@ -1,0 +1,16 @@
+-- SPDX-FileCopyrightText: 2021 Arthur Breitman
+-- SPDX-License-Identifier: LicenseRef-MIT-Arthur-Breitman
+
+module Test.SegCFMM.Storage
+  ( defaultStorage
+  ) where
+
+import Michelson.Typed
+
+import SegCFMM.Types
+import Util (fetchValue)
+
+defaultStorage :: Storage
+defaultStorage =
+  fromVal ($(fetchValue @Storage "test/storage_default.tz" "STORAGE_PATH"))
+

--- a/haskell/test/Test/SegCFMM/Types.hs
+++ b/haskell/test/Test/SegCFMM/Types.hs
@@ -2,7 +2,8 @@
 -- SPDX-License-Identifier: LicenseRef-MIT-Arthur-Breitman
 
 module Test.SegCFMM.Types
-  ( unit_TypesMatch
+  ( unit_ContractTypesMatch
+  , unit_StorageTypesMatch
   ) where
 
 import Universum
@@ -11,7 +12,13 @@ import Test.HUnit (Assertion)
 
 import Michelson.Typed (Contract)
 
+import SegCFMM.Types (Storage)
 import Test.SegCFMM.Contract
+import Test.SegCFMM.Storage
 
-unit_TypesMatch :: Assertion
-unit_TypesMatch = evaluateNF_ @(Contract _ _) segCFMMContractLigo
+unit_ContractTypesMatch :: Assertion
+unit_ContractTypesMatch = evaluateNF_ @(Contract _ _) segCFMMContract
+
+-- TODO: Removed when `defaultStorage` is used in the tests.
+unit_StorageTypesMatch :: Assertion
+unit_StorageTypesMatch = void $ pure (defaultStorage :: Storage)

--- a/ligo/consts.mligo
+++ b/ligo/consts.mligo
@@ -5,7 +5,13 @@
 #else
 #define CONSTS_MLIGO
 
+(* Note: `half_bps_pow` only supports sqrt_price up to this tick index: `2^20 - 1`. *)
 [@inline] let const_max_tick : nat = 1048575n
+
+(* Invalid tick index. Shouldn't be reached. Cannot be defined as failwith
+    due to `compile-storage` returning the error.
+*)
+[@inline] let impossible_tick : nat = const_max_tick + 1n
 
 (* Some contract specific constants, to be edited per deployment
  todo implement burn [@inline] let const_ctez_burn_fee_bps : nat = 5n *)

--- a/ligo/defaults.mligo
+++ b/ligo/defaults.mligo
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2021 Arthur Breitman
+// SPDX-License-Identifier: LicenseRef-MIT-Arthur-Breitman
+
+#include "types.mligo"
+#include "consts.mligo"
+
+let default_storage : storage =
+
+  let min_tick_state =
+    { prev = { i = -impossible_tick }
+    ; next = { i = int(const_max_tick) }
+    ; liquidity_net = 0
+    ; n_positions = 1n (* prevents garbage collection *)
+    ; seconds_outside = 0n
+    ; fee_growth_outside = {x = { x128 = 0n } ; y = { x128 = 0n }}
+    ; seconds_per_liquidity_outside = {x128 = 0n}
+    ; sqrt_price = { x80 = 21n }
+    (* ^ round(sqrt(exp(0.0001)^-1048575) * 2^80) *)
+    } in
+
+  let max_tick_state =
+    { prev = { i = -const_max_tick }
+    ; next = { i = int(impossible_tick) }
+    ; liquidity_net = 0
+    ; n_positions = 1n (* prevents garbage collection *)
+    ; seconds_outside = 0n
+    ; fee_growth_outside = {x = { x128 = 0n } ; y = { x128 = 0n }}
+    ; seconds_per_liquidity_outside = {x128 = 0n}
+    ; sqrt_price = { x80 = 71107673757466966990985105047137336834554167630n }
+    (* ^ round(sqrt(exp(0.0001)^1048575) * 2^80) *)
+    } in
+
+  let ticks = Big_map.literal [
+      ({ i = -const_max_tick }, min_tick_state);
+      ({ i = int(const_max_tick) }, max_tick_state)
+  ] in
+
+  { liquidity = 0n
+  ; sqrt_price = { x80 = 0n }
+  ; cur_tick_index = { i = 0 }
+  ; cur_tick_witness  = { i = -const_max_tick }
+  ; fee_growth = { x = { x128 = 0n }; y = { x128 = 0n } }
+  ; balance = { x = 0n ; y = 0n }
+  ; ticks = ticks
+  ; positions = (Big_map.empty : position_map)
+  ; position_indexes = (Big_map.empty : position_index_map)
+  ; time_weighted_ic_sum = 0
+  ; last_ic_sum_update = epoch_time
+  ; seconds_per_liquidity_cumulative = { x128 = 0n }
+  ; new_position_id = 0n
+  ; metadata = (Big_map.empty : metadata_map)
+  ; operators = (Big_map.empty : operators)
+  }

--- a/ligo/main.mligo
+++ b/ligo/main.mligo
@@ -8,6 +8,8 @@
 #include "math.mligo"
 #include "swaps.mligo"
 #include "token/fa2.mligo"
+#include "defaults.mligo"
+
 
 #if !DUMMY_PRAGMA1
 This is an example of conditionally present code, remove it once normal pragmas are set.


### PR DESCRIPTION
## Description

Problem: Following the discussion in which the tick initialization is dependent
on existing "witnesses" ticks, there needs to be the two "extreme" ticks
(highest and lowest allowed indexes) at origination.

We need to pick a large number to represent this "infinite" index.

Solution: Add `default_storage` which is mean to be used at the
origination, add the initialized `ticks` with infinite index.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

[//]: # (Here you can add a link to the corresponding issue tracker, e. g. https://issues.serokell.io/issue/AD-)
[//]: # (For GitHub/GitLab issues it is better to use just hash symbol or exclamation mark as it is more resistant to repo movements)
[//]: # (In this case please also prefix the link with "Resolves" keyword)
[//]: # (See https://docs.gitlab.com/ee/user/project/issues/managing_issues.html#closing-issues-automatically)
[//]: # (See https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords)
## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves TCFMM-12

Depends on #6 
## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

[//]: # (Update link to style guide if necesary or remove if it's not present)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
Problem: `liquidity_net` (old `liquidity_delta`) is currently always
subtracted, that does not seem right.

Solution: when we exit a tick while going up, add `liquidity_net`
instead of subtracting it.