### PR TITLE
[TCFMM-16] Fix position initialization

### DIFF
--- a/ligo/main.mligo
+++ b/ligo/main.mligo
@@ -86,10 +86,7 @@ let calc_fee_growth_inside (s : storage) (lower_tick_index : tick_index) (upper_
       y = {x128 = assert_nat (s.fee_growth.y.x128 - fee_above.y.x128 - fee_below.y.x128, internal_315) };
     }
 
-let collect_fees (s : storage) (key : position_index) : storage * balance_nat =
-    let position = match Big_map.find_opt key s.positions with
-    | None -> (failwith "position does not exist" : position_state) // TODO: [TCFMM-16] This error is a bug.
-    | Some position -> position in
+let collect_fees (s : storage) (key : position_index) (position : position_state) : storage * balance_nat =
     let fee_growth_inside = calc_fee_growth_inside s key.lower_tick_index key.upper_tick_index in
     let fees = {
         x = Bitwise.shift_right ((assert_nat (fee_growth_inside.x.x128 - position.fee_growth_inside_last.x.x128, internal_316)) * position.liquidity) 128n;
@@ -126,7 +123,7 @@ let set_position (s : storage) (i_l : tick_index) (i_u : tick_index) (i_l_l : ti
         if is_new then
             (s, {x = 0n; y = 0n})
         else
-            collect_fees s position_key
+            collect_fees s position_key position
         in
     (* Update liquidity of position. *)
     let liquidity_new = assert_nat (position.liquidity + liquidity_delta, internal_liquidity_below_zero_err) in

--- a/ligo/main.mligo
+++ b/ligo/main.mligo
@@ -122,7 +122,12 @@ let set_position (s : storage) (i_l : tick_index) (i_u : tick_index) (i_l_l : ti
                 } in
         (new_position, true) in
     (* Get accumulated fees for this position. *)
-    let s, fees = collect_fees s position_key in
+    let s, fees =
+        if is_new then
+            (s, {x = 0n; y = 0n})
+        else
+            collect_fees s position_key
+        in
     (* Update liquidity of position. *)
     let liquidity_new = assert_nat (position.liquidity + liquidity_delta, internal_liquidity_below_zero_err) in
     let position = {position with liquidity = liquidity_new} in

--- a/ligo/main.mligo
+++ b/ligo/main.mligo
@@ -61,32 +61,42 @@ let incr_n_positions (ticks : tick_map) (i : tick_index) (incr : int) =
     else
         Big_map.update i (Some {tick with n_positions = n_pos}) ticks
 
+let calc_fee_growth_inside (s : storage) (lower_tick_index : tick_index) (upper_tick_index : tick_index) : balance_nat_x128 =
+    let lower_tick = get_tick s.ticks lower_tick_index internal_tick_not_exist_err in
+    let upper_tick = get_tick s.ticks upper_tick_index internal_tick_not_exist_err in
+
+    // equation 6.17
+    let fee_above =
+        if s.cur_tick_index.i >= upper_tick_index.i then
+            { x = {x128 = assert_nat (s.fee_growth.x.x128 - upper_tick.fee_growth_outside.x.x128, internal_311) };
+              y = {x128 = assert_nat (s.fee_growth.y.x128 - upper_tick.fee_growth_outside.y.x128, internal_311) };
+            }
+        else
+            upper_tick.fee_growth_outside in
+    // equation 6.18
+    let fee_below =
+        if s.cur_tick_index.i >= lower_tick_index.i then
+            lower_tick.fee_growth_outside
+        else
+            { x = {x128 = assert_nat (s.fee_growth.x.x128 - lower_tick.fee_growth_outside.x.x128, internal_312) };
+              y = {x128 = assert_nat (s.fee_growth.y.x128 - lower_tick.fee_growth_outside.y.x128, internal_312) };
+            } in
+    // equation 6.19
+    { x = {x128 = assert_nat (s.fee_growth.x.x128 - fee_above.x.x128 - fee_below.x.x128, internal_314) };
+      y = {x128 = assert_nat (s.fee_growth.y.x128 - fee_above.y.x128 - fee_below.y.x128, internal_315) };
+    }
+
 let collect_fees (s : storage) (key : position_index) : storage * balance_nat =
     let position = match Big_map.find_opt key s.positions with
     | None -> (failwith "position does not exist" : position_state) // TODO: [TCFMM-16] This error is a bug.
     | Some position -> position in
-    let tick_lo = get_tick s.ticks key.lower_tick_index internal_tick_not_exist_err in
-    let tick_hi = get_tick s.ticks key.upper_tick_index internal_tick_not_exist_err in
-    let f_a = if s.cur_tick_index.i >= key.upper_tick_index.i then
-        { x = {x128 = assert_nat (s.fee_growth.x.x128 - tick_hi.fee_growth_outside.x.x128, internal_311)};
-          y = {x128 = assert_nat (s.fee_growth.y.x128 - tick_hi.fee_growth_outside.y.x128, internal_311)}}
-    else
-        tick_hi.fee_growth_outside in
-    let f_b = if s.cur_tick_index.i >= key.lower_tick_index.i then
-        tick_lo.fee_growth_outside
-    else
-        { x = {x128 = assert_nat (s.fee_growth.x.x128 - tick_lo.fee_growth_outside.x.x128, internal_312)} ;
-          y = {x128 = assert_nat (s.fee_growth.y.x128 - tick_lo.fee_growth_outside.y.x128, internal_312)} } in
-    let fee_growth_inside = {
-        x = {x128 = assert_nat (s.fee_growth.x.x128 - f_a.x.x128 - f_b.x.x128, internal_314)} ;
-        y = {x128 = assert_nat (s.fee_growth.y.x128 - f_a.y.x128 - f_b.y.x128, internal_315)} } in
+    let fee_growth_inside = calc_fee_growth_inside s key.lower_tick_index key.upper_tick_index in
     let fees = {
         x = Bitwise.shift_right ((assert_nat (fee_growth_inside.x.x128 - position.fee_growth_inside_last.x.x128, internal_316)) * position.liquidity) 128n;
         y = Bitwise.shift_right ((assert_nat (fee_growth_inside.y.x128 - position.fee_growth_inside_last.y.x128, internal_317)) * position.liquidity) 128n} in
     let position = {position with fee_growth_inside_last = fee_growth_inside} in
     let positions = Big_map.update key (Some position) s.positions in
     ({s with positions = positions}, fees)
-
 
 let set_position (s : storage) (i_l : tick_index) (i_u : tick_index) (i_l_l : tick_index) (i_u_l : tick_index) (liquidity_delta : int) (to_x : address) (to_y : address) : result =
     (* Initialize ticks if need be. *)
@@ -105,7 +115,12 @@ let set_position (s : storage) (i_l : tick_index) (i_u : tick_index) (i_l_l : ti
     (* Grab existing position or create an empty one *)
     let (position, is_new) = match (Big_map.find_opt position_key s.positions) with
     | Some position -> (position, false)
-    | None -> ({liquidity = 0n ; fee_growth_inside_last = {x = {x128 = 0n}; y = {x128 = 0n}}}, true) in
+    | None ->
+        let new_position =
+                { liquidity = 0n;
+                  fee_growth_inside_last = calc_fee_growth_inside s position_key.lower_tick_index position_key.upper_tick_index;
+                } in
+        (new_position, true) in
     (* Get accumulated fees for this position. *)
     let s, fees = collect_fees s position_key in
     (* Update liquidity of position. *)


### PR DESCRIPTION
[//]: # (This is a template of a pull request template.)
[//]: # (You should modify it considering specifics of a particular repository and put it there.)
[//]: # (Comments like this are meta-comments, they shouldn't be present in the final template.)
[//]: # (Comments starting with '<!---' are intended to stay in the final template.)

[//]: # (Keep in mind that it's only a template which contains items relevant to almost all conceivable repository.)
[//]: # (There can be other important items relevant to your repository that you can add here.)

## Description


This PR fixes a couple of bugs in the initialization of positions:

1. `fee_growth_inside_last`
      ```
      let set_position (s : storage) (i_l : tick_index) (i_u : tick_index) (i_l_l : tick_index) (i_u_l : tick_index) (liquidity_delta : int) (to_x : address) (to_y : address) : result =
          ...
          (* Grab existing position or create an empty one *)
          let (position, is_new) = match (Big_map.find_opt position_key s.positions) with
          | Some position -> (position, false)
          | None -> ({liquidity = 0n ; fee_growth_inside_last = {x = 0n; y = 0n} ; seconds_per_liquidity_inside = 0n}, true) in
                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                               
      ```

      `fee_growth_inside_last` should account for all the fees accrued up until the last time the position was touched (created or updated).

      If we're creating a new position, `fee_growth_inside_last` should be initialized to the current `fee_growth_inside`.


2. `collect_fees`

      ```
          (* Grab existing position or create an empty one *)
          let (position, is_new) = match (Big_map.find_opt position_key s.positions) with
          | Some position -> (position, false)
          | None -> ({liquidity = 0n ; fee_growth_inside_last = {x = 0n; y = 0n} ; seconds_per_liquidity_inside = 0n}, true) in

          (* Get accumulated fees for this position. *)
          let s, fees = collect_fees s position_key in
      ```

      `set_position` always calls `collect_fees`, regardless of whether this is a new position or we're editing an existing one.
      But then `collect_fees` fails if the position does not exist yet. So it looks like `set_position` will always fail when setting up a new position.

      Furthermore, `collect_fees` performs a bigmap lookup to find the position. But this seems redundant, because `set_position` already performed the exact same lookup _before_ calling `collect_fees`.


## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves TCFMM-16

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

[//]: # (Update link to style guide if necesary or remove if it's not present)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
