### PR TITLE
[TCFMM-21] Fix price move in `y_to_x`

### DIFF
--- a/ligo/swaps.mligo
+++ b/ligo/swaps.mligo
@@ -16,7 +16,7 @@ let rec x_to_y_rec (p : x_to_y_rec_param) : x_to_y_rec_param =
         (* The fee that would be extracted from selling dx. *)
         let fee  = ceildiv (p.dx * const_fee_bps) 10000n in
         (* What the new price will be, assuming it's within the current tick. *)
-        let sqrt_price_new = sqrt_price_move p.s.liquidity p.s.sqrt_price (assert_nat (p.dx - fee, internal_fee_more_than_100_percent_err)) in
+        let sqrt_price_new = sqrt_price_move_x p.s.liquidity p.s.sqrt_price (assert_nat (p.dx - fee, internal_fee_more_than_100_percent_err)) in
         (* What the new value of ic will be. *)
         let i_c_new = {i = p.s.cur_tick_index.i + floor_log_half_bps_x80(sqrt_price_new, p.s.sqrt_price)} in
         if i_c_new.i >= p.s.cur_tick_witness.i then
@@ -72,13 +72,13 @@ let rec x_to_y_rec (p : x_to_y_rec_param) : x_to_y_rec_param =
 
 
 let rec y_to_x_rec (p : y_to_x_rec_param) : y_to_x_rec_param =
- if p.s.liquidity = 0n then
+    if p.s.liquidity = 0n then
         p
     else
         (* The fee that would be extracted from selling dy. *)
         let fee  = ceildiv (p.dy * const_fee_bps) 10000n in
         (* What the new price will be, assuming it's within the current tick. *)
-        let sqrt_price_new = sqrt_price_move p.s.liquidity p.s.sqrt_price (assert_nat (p.dy - fee, internal_fee_more_than_100_percent_err)) in
+        let sqrt_price_new = sqrt_price_move_y p.s.liquidity p.s.sqrt_price (assert_nat (p.dy - fee, internal_fee_more_than_100_percent_err)) in
         (* What the new value of ic will be. *)
         let i_c_new = {i = p.s.cur_tick_index.i + floor_log_half_bps_x80(sqrt_price_new, p.s.sqrt_price)} in
         let tick = get_tick p.s.ticks p.s.cur_tick_witness internal_tick_not_exist_err in


### PR DESCRIPTION
## Description
Problem: The `sqrt_price_move` functoin expects to be called with a `dx`
parameter.

However, in `y_to_x_rec`, it is called with `dy` instead of `dx`.

Solution: Write a function that computes the price move from `dy` (see
equation 6.13 from the whitepaper).

[//]: # (Here you can add a link to the corresponding issue tracker, e. g. https://issues.serokell.io/issue/AD-)
[//]: # (For GitHub/GitLab issues it is better to use just hash symbol or exclamation mark as it is more resistant to repo movements)
[//]: # (In this case please also prefix the link with "Resolves" keyword)
[//]: # (See https://docs.gitlab.com/ee/user/project/issues/managing_issues.html#closing-issues-automatically)
[//]: # (See https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords)
## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves TCFMM-21

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

[//]: # (Update link to style guide if necesary or remove if it's not present)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
