### PR TITLE
[TCFMM-20] fix `seconds_outside`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ TS_OUT ?= typescript
 # Utility function to escape double quotes
 escape_double_quote = $(subst $\",$\\",$(1))
 
-.PHONY: all lib metadata test typescript clean
+.PHONY: all lib metadata error-codes test typescript clean
 
 # Builds LIGO contract. Arguments:
 #   1: The source file
@@ -63,6 +63,9 @@ metadata: lib all
 		--y-token-symbol $(y_token_symbol) --y-token-name $(call escape_double_quote,$(y_token_name)) \
 		--y-token-decimals $(y_token_decimals) \
 		" EXEC_OUTPUT=$(output)
+
+error-codes:
+	stack scripts/generate_error_code.hs
 
 test: all
 	$(MAKE) -C haskell test PACKAGE=segmented-cfmm \

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -61,5 +61,6 @@ Here is a summary of all the error codes thrown by the contract.
 | 318 | `internal_sqrt_price_grow_err_1` | Thrown when `s.i_c < i_l.i` and the `sqrt_price` happened not to grow monotonically with tick indices (This is an invariant of the contract). |
 | 319 | `internal_sqrt_price_grow_err_2` | Thrown when `i_l.i <= s.i_c && s.i_c < i_u.i` and the `sqrt_price` happened not to grow monotonically with tick indices (This is an invariant of the contract). |
 | 320 | `internal_impossible_err` | Generic impossible error. |
+| 321 | `internal_negative_seconds_outside_err` | Thrown when `seconds_outside` is negative. |
 
 

--- a/ligo/errors.mligo
+++ b/ligo/errors.mligo
@@ -113,6 +113,9 @@
 (* Generic impossible error. *)
 [@inline] let internal_impossible_err = 320n
 
+(* Thrown when `seconds_outside` is negative. *)
+[@inline] let internal_negative_seconds_outside_err = 321n
+
 
 
 #endif

--- a/ligo/swaps.mligo
+++ b/ligo/swaps.mligo
@@ -51,9 +51,11 @@ let rec x_to_y_rec (p : x_to_y_rec_param) : x_to_y_rec_param =
             let fee_growth_new = {p.s.fee_growth with x=fee_growth_x_new} in
             (* Flip time growth. *)
             let seconds_outside_new = assert_nat ((Tezos.now - epoch_time) - tick.seconds_outside, internal_epoch_bigger_than_now_err) in
+            (* Update tick state. *)
             let tick_new = {tick with
-                fee_growth_outside = fee_growth_outside_new ;
-                seconds_outside = seconds_outside_new } in
+                    fee_growth_outside = fee_growth_outside_new ;
+                    seconds_outside = seconds_outside_new ;
+                } in
             let ticks_new = Big_map.update p.s.cur_tick_witness (Some tick_new) p.s.ticks  in
             (* Update global state. *)
             let s_new = {p.s with
@@ -113,7 +115,13 @@ let rec y_to_x_rec (p : y_to_x_rec_param) : y_to_x_rec_param =
             let fee_growth_outside_new = {tick.fee_growth_outside with
                 y = {x128 = assert_nat (fee_growth_y_new.x128 - tick.fee_growth_outside.y.x128, flip_fee_growth_outside_err)}} in
             let fee_growth_new = {p.s.fee_growth with y=fee_growth_y_new} in
-            let tick_new = {tick with fee_growth_outside = fee_growth_outside_new} in
+            (* Flip time growth. *)
+            let seconds_outside_new = assert_nat ((Tezos.now - epoch_time) - tick.seconds_outside, internal_epoch_bigger_than_now_err) in
+            (* Update tick state. *)
+            let tick_new = { tick with
+                    fee_growth_outside = fee_growth_outside_new ;
+                    seconds_outside = seconds_outside_new ;
+                } in
             let ticks_new = Big_map.update p.s.cur_tick_witness (Some tick_new) p.s.ticks  in
             (* Update global state. *)
             let s_new = {p.s with

--- a/ligo/swaps.mligo
+++ b/ligo/swaps.mligo
@@ -50,7 +50,7 @@ let rec x_to_y_rec (p : x_to_y_rec_param) : x_to_y_rec_param =
                 x = {x128 = assert_nat (fee_growth_x_new.x128 - tick.fee_growth_outside.x.x128, flip_fee_growth_outside_err)}} in
             let fee_growth_new = {p.s.fee_growth with x=fee_growth_x_new} in
             (* Flip time growth. *)
-            let seconds_outside_new = assert_nat ((Tezos.now - epoch_time) - tick.seconds_outside, internal_epoch_bigger_than_now_err) in
+            let seconds_outside_new = assert_nat ((Tezos.now - epoch_time) - tick.seconds_outside, internal_negative_seconds_outside_err) in
             (* Update tick state. *)
             let tick_new = {tick with
                     fee_growth_outside = fee_growth_outside_new ;
@@ -116,7 +116,7 @@ let rec y_to_x_rec (p : y_to_x_rec_param) : y_to_x_rec_param =
                 y = {x128 = assert_nat (fee_growth_y_new.x128 - tick.fee_growth_outside.y.x128, flip_fee_growth_outside_err)}} in
             let fee_growth_new = {p.s.fee_growth with y=fee_growth_y_new} in
             (* Flip time growth. *)
-            let seconds_outside_new = assert_nat ((Tezos.now - epoch_time) - tick.seconds_outside, internal_epoch_bigger_than_now_err) in
+            let seconds_outside_new = assert_nat ((Tezos.now - epoch_time) - tick.seconds_outside, internal_negative_seconds_outside_err) in
             (* Update tick state. *)
             let tick_new = { tick with
                     fee_growth_outside = fee_growth_outside_new ;

--- a/scripts/generate_error_code.hs
+++ b/scripts/generate_error_code.hs
@@ -10,9 +10,9 @@
 -- | Script for adding new error to ligo and also update the docs.
 module GenerateErrorCode where
 
+import Data.String.Interpolate (i)
 import Prelude ()
 import Universum
-import Data.String.Interpolate (i)
 
 data ErrorItem = ErrorItem
   { eiLabel :: Text
@@ -174,6 +174,11 @@ internalErrors =
       { eiLabel = "internal_impossible_err"
       , eiCode = 320
       , eiDesc = "Generic impossible error."
+      }
+    , ErrorItem
+      { eiLabel = "internal_negative_seconds_outside_err"
+      , eiCode = 321
+      , eiDesc = "Thrown when `seconds_outside` is negative."
       }
 
   ]


### PR DESCRIPTION
## Description

Problem: the field `seconds_outside` is updated in `x_to_y_rec` but not
in `y_to_x_rec`. This seems to have been overlooked.

Solution: update `seconds_outside` in `y_to_x_rec` as well.


<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

[//]: # (Here you can add a link to the corresponding issue tracker, e. g. https://issues.serokell.io/issue/AD-)
[//]: # (For GitHub/GitLab issues it is better to use just hash symbol or exclamation mark as it is more resistant to repo movements)
[//]: # (In this case please also prefix the link with "Resolves" keyword)
[//]: # (See https://docs.gitlab.com/ee/user/project/issues/managing_issues.html#closing-issues-automatically)
[//]: # (See https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords)
## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves TCFMM-20

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

[//]: # (Update link to style guide if necesary or remove if it's not present)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
