### PR TITLE
[Chore] Remove balance field from storage and use recursive updates

### DIFF
--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -56,7 +56,6 @@ Here is a summary of all the error codes thrown by the contract.
 | 307 | `internal_307` | Thrown when `(p.dx - dx_consummed)` or `(p.dy - dy_consummed)` is not nat. |
 | 308 | `internal_liquidity_below_zero_err` | Liquidity went below zero. |
 | 309 | `internal_309` | Thrown when `(p.dx - r.dx)` is not nat. |
-| 310 | `internal_insufficient_balance_err` | Contract does not have enough liquidity to execute the swap. |
 | 311 | `internal_311` | Thrown when `s.cur_tick_index.i >= upper_tick_index.i` and `(s.fee_growth.x - upper_tick.fee_growth_outside.x)` (or `y`) is not nat. |
 | 312 | `internal_312` | Thrown when `s.cur_tick_index.i < lower_tick_index.i` and `(s.fee_growth.x - lower_tick.fee_growth_outside.x)` (or `y`) is not nat. |
 | 313 | `internal_position_underflow_err` | Number of positions underflow. |

--- a/haskell/src/SegCFMM/Types.hs
+++ b/haskell/src/SegCFMM/Types.hs
@@ -190,7 +190,6 @@ data Storage = Storage
   , sFeeGrowth :: PerToken (X 128 Natural)
     -- ^ Represent the total amount of fees that have been earned per unit of
     -- virtual liquidity, over the entire history of the contract.
-  , sBalance :: PerToken Natural
   , sTicks :: TickMap
     -- ^ Ticks' states.
   , sPositions :: PositionMap

--- a/ligo/defaults.mligo
+++ b/ligo/defaults.mligo
@@ -42,7 +42,6 @@ let default_storage (constants : constants) : storage =
   ; cur_tick_index = { i = 0 }
   ; cur_tick_witness  = { i = -const_max_tick }
   ; fee_growth = { x = { x128 = 0n }; y = { x128 = 0n } }
-  ; balance = { x = 0n ; y = 0n }
   ; ticks = ticks
   ; positions = (Big_map.empty : position_map)
   ; position_indexes = (Big_map.empty : position_index_map)

--- a/ligo/errors.mligo
+++ b/ligo/errors.mligo
@@ -98,9 +98,6 @@
 (* Thrown when `(p.dx - r.dx)` is not nat. *)
 [@inline] let internal_309 = 309n
 
-(* Contract does not have enough liquidity to execute the swap. *)
-[@inline] let internal_insufficient_balance_err = 310n
-
 (* Thrown when `s.cur_tick_index.i >= upper_tick_index.i` and `(s.fee_growth.x - upper_tick.fee_growth_outside.x)` (or `y`) is not nat. *)
 [@inline] let internal_311 = 311n
 

--- a/ligo/swaps.mligo
+++ b/ligo/swaps.mligo
@@ -148,8 +148,7 @@ let update_storage_x_to_y (s : storage) (dx : nat) : (nat * nat * storage) =
     let r = x_to_y_rec {s = s ; dx = dx ; dy = 0n} in
     let dx_spent = assert_nat (dx - r.dx, internal_309) in
     let dy_received = r.dy in
-    let s_new = {s with balance = {x = s.balance.x + dx_spent ;  y = assert_nat (s.balance.y - dy_received, internal_insufficient_balance_err)}} in
-    (dx_spent, dy_received, s_new)
+    (dx_spent, dy_received, r.s)
 
 
 (* Trade up to a quantity dx of asset x, receives dy *)
@@ -170,13 +169,12 @@ let y_to_x (s : storage) (p : y_to_x_param) : result =
     let r = y_to_x_rec {s = s ; dy = p.dy ; dx = 0n} in
     let dy_spent = assert_nat (p.dy - r.dy, internal_309) in
     let dx_received = r.dx in
-    let s_new = {s with balance = {y = s.balance.y + dy_spent ;  x = assert_nat (s.balance.x - dx_received, internal_insufficient_balance_err)}} in
     if dx_received < p.min_dx then
         (failwith smaller_than_min_asset_err : result)
     else
         let op_receive_y = y_transfer Tezos.sender Tezos.self_address dy_spent s.constants in
         let op_send_x = x_transfer Tezos.self_address p.to_dx dx_received s.constants in
-        ([op_receive_y ; op_send_x], s_new)
+        ([op_receive_y ; op_send_x], r.s)
 
 
 (* Trade X with X' in a different contract. *)

--- a/ligo/types.mligo
+++ b/ligo/types.mligo
@@ -311,9 +311,6 @@ type storage = {
     *)
     fee_growth : balance_nat_x128 ;
 
-    (* Tokens' amounts. *)
-    balance : balance_nat ;
-
     (* States of all initialized ticks. *)
     ticks : tick_map ;
 

--- a/scripts/generate_error_code.hs
+++ b/scripts/generate_error_code.hs
@@ -129,8 +129,7 @@ internalErrors = errorsEnumerate 300
   , "internal_309"
       :? "Thrown when `(p.dx - r.dx)` is not nat."
 
-  , "internal_insufficient_balance_err"
-      :? "Contract does not have enough liquidity to execute the swap."
+  , removedError
 
   , "internal_311"
       :? "Thrown when `s.cur_tick_index.i >= upper_tick_index.i` and `(s.fee_growth.x - upper_tick.fee_growth_outside.x)` (or `y`) is not nat."


### PR DESCRIPTION
## Description

Problem: the balance field from the storage is updated during swaps,
but has no use in the contract. Moreover, this is the only update to
the storage that we do in swaps, due to a bug in the variables used.

Solution: remove the balance field and fix the bug.

## Related issue(s)

Related to TCFMM-28

## :white_check_mark: Checklist for your Pull Request

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [Specification](../tree/master/docs/specification.md)
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

[//]: # (Update link to style guide if necesary or remove if it's not present)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [ ] My code complies with the [style guide](../tree/master/docs/code-style.md).
