### PR TITLE
[TCFMM-29] Move ladder to the storage

### DIFF
--- a/haskell/src/SegCFMM/Types.hs
+++ b/haskell/src/SegCFMM/Types.hs
@@ -219,6 +219,9 @@ data Storage = Storage
   , sOperators :: Operators
     -- ^ FA2 operators
   , sConstants :: Constants
+    -- ^ Settable constants of the contract
+  , sLadder :: Ladder
+    -- ^ Exponents ladder for power calculations
   }
 
 -- Needed by `sMetadata`
@@ -393,6 +396,19 @@ data Constants = Constants
   }
   deriving stock Eq
 
+
+type Ladder = BigMap LadderKey FixedPoint
+
+data FixedPoint = FixedPoint
+  { fpV :: Natural
+  , fpOffset :: Integer
+  } deriving stock (Ord, Eq)
+
+data LadderKey = LadderKey
+  { lkExp :: Natural
+  , lkPositive :: Bool
+  } deriving stock (Ord, Eq)
+
 ------------------------------------------------------------------------
 -- Operators
 ------------------------------------------------------------------------
@@ -541,6 +557,24 @@ instance HasAnnotation Constants where
 
 deriveRPCWithStrategy "Constants" ligoLayout
 deriving via (GenericBuildable ConstantsRPC) instance Buildable ConstantsRPC
+
+customGeneric "FixedPoint" ligoLayout
+deriving via (GenericBuildable FixedPoint) instance Buildable FixedPoint
+deriving anyclass instance IsoValue FixedPoint
+instance HasAnnotation FixedPoint where
+  annOptions = segCfmmAnnOptions
+
+deriveRPCWithStrategy "FixedPoint" ligoLayout
+deriving via (GenericBuildable FixedPointRPC) instance Buildable FixedPointRPC
+
+customGeneric "LadderKey" ligoLayout
+deriving via (GenericBuildable LadderKey) instance Buildable LadderKey
+deriving anyclass instance IsoValue LadderKey
+instance HasAnnotation LadderKey where
+  annOptions = segCfmmAnnOptions
+
+deriveRPCWithStrategy "LadderKey" ligoLayout
+deriving via (GenericBuildable LadderKeyRPC) instance Buildable LadderKeyRPC
 
 customGeneric "Storage" ligoLayout
 deriving via (GenericBuildable Storage) instance Buildable Storage

--- a/ligo/consts.mligo
+++ b/ligo/consts.mligo
@@ -11,7 +11,9 @@
 #else
 #define CONSTS_MLIGO
 
-(* Note: `half_bps_pow` only supports sqrt_price up to this tick index: `2^20 - 1`. *)
+(* Note: `half_bps_pow` only supports sqrt_price up to this tick index: `2^20 - 1`
+   when originated with the 'default_ladder'.
+*)
 [@inline] let const_max_tick : nat = 1048575n
 
 (* Invalid tick index. Shouldn't be reached. Cannot be defined as failwith

--- a/ligo/defaults.mligo
+++ b/ligo/defaults.mligo
@@ -6,6 +6,82 @@
 #include "errors.mligo"
 #include "math.mligo"
 
+(* ladder explanation
+
+relative error for each ladder element is  2^(-86)
+In the worst case, the product of all the mantissas is
+
+264282414466372656233620232085\
+891076152819178199188386987876\
+130399611230776317562564102356\
+510887554505841649869995115306\
+153657257592287884078198212867\
+452334369951588805003086042064\
+419487861191053453237580032868\
+756342299942389805587432570501\
+862667904215683136301357731738\
+924376078014888356296733854672\
+700413177506511695535173325976\
+383558174492550937991343710044\
+641323722927702345262447930316\
+774974009739628156118404725209\
+505333623465138071036374956137\
+115703347618301958744836243752\
+685553646224208937741458987598\
+9769554995549619185305600000
+
+A 1786 bit number.
+
+Also in the worse case, the product of all the error terms is (1 + total_err) with |total_err| < 2^(-81)
+This ensures that the tick index can be matched to a square root price with over 80 bits of precision
+
+*)
+let default_ladder : ladder = Big_map.literal
+  [ ({exp=0n; positive=true}, {v=38687560557337355742483221n; offset=-85}) (* 2^0 *)
+  ; ({exp=1n; positive=true}, {v=38689494983725479307861971n; offset=-85})
+  ; ({exp=2n; positive=true}, {v=38693364126677775184793561n; offset=-85})
+  ; ({exp=3n; positive=true}, {v=38701103573421987005215721n; offset=-85})
+  ; ({exp=4n; positive=true}, {v=38716587111352494729706462n; offset=-85})
+  ; ({exp=5n; positive=true}, {v=38747572773653928660613512n; offset=-85})
+  ; ({exp=6n; positive=true}, {v=38809618513447185627569983n; offset=-85})
+  ; ({exp=7n; positive=true}, {v=38934008210058939100663682n; offset=-85})
+  ; ({exp=8n; positive=true}, {v=39183984934869404935943141n; offset=-85})
+  ; ({exp=9n; positive=true}, {v=39688763633815974521145659n; offset=-85})
+  ; ({exp=10n; positive=true}, {v=40717912888646086984030507n; offset=-85})
+  ; ({exp=11n; positive=true}, {v=42856962434838368098529959n; offset=-85})
+  ; ({exp=12n; positive=true}, {v=47478079282778087338933597n; offset=-85})
+  ; ({exp=13n; positive=true}, {v=29134438707490415855866100n; offset=-84})
+  ; ({exp=14n; positive=true}, {v=43882733799120415566608322n; offset=-84})
+  ; ({exp=15n; positive=true}, {v=49778031622173924435819796n; offset=-83})
+  ; ({exp=16n; positive=true}, {v=32025492072892644517427309n; offset=-80})
+  ; ({exp=17n; positive=true}, {v=53023938993515524338629870n; offset=-76})
+  ; ({exp=18n; positive=true}, {v=36338278329035183585718600n; offset=-66})
+  ; ({exp=19n; positive=true}, {v=34133361681864713959105863n; offset=-47})
+  (* ; ({exp=20n; positive=true}, {v=30116777038798852995368017; offset=-9})  2^20  *)
+  ; ({exp=0n; positive=false}, {v=19341845997356488514015570n; offset=-84}) (* -2^0 *)
+  ; ({exp=1n; positive=false}, {v=2417609866154190654524678n; offset=-81})
+  ; ({exp=2n; positive=false}, {v=38677889876083546261210550n; offset=-85})
+  ; ({exp=3n; positive=false}, {v=38670155071614559132217310n; offset=-85})
+  ; ({exp=4n; positive=false}, {v=19327345051392939314248854n; offset=-84})
+  ; ({exp=5n; positive=false}, {v=19311889358453304431405214n; offset=-84})
+  ; ({exp=6n; positive=false}, {v=77124060166079386301517011n; offset=-86})
+  ; ({exp=7n; positive=false}, {v=38438828813936263312862610n; offset=-85})
+  ; ({exp=8n; positive=false}, {v=76387211720013513967242610n; offset=-86})
+  ; ({exp=9n; positive=false}, {v=75415686436335201065707301n; offset=-86})
+  ; ({exp=10n; positive=false}, {v=73509547540888574991368714n; offset=-86})
+  ; ({exp=11n; positive=false}, {v=17460146398643019245576278n; offset=-84})
+  ; ({exp=12n; positive=false}, {v=126085780994910985395717054n; offset=-87})
+  ; ({exp=13n; positive=false}, {v=102735988268212419722671870n; offset=-87})
+  ; ({exp=14n; positive=false}, {v=68208042073114503830679361n; offset=-87})
+  ; ({exp=15n; positive=false}, {v=60130046442422405275353178n; offset=-88})
+  ; ({exp=16n; positive=false}, {v=11682706336100247487260846n; offset=-88})
+  ; ({exp=17n; positive=false}, {v=56449132412055094618915006n; offset=-95})
+  ; ({exp=18n; positive=false}, {v=20592303012757789234393034n; offset=-103})
+  ; ({exp=19n; positive=false}, {v=1370156647050591448120178n; offset=-118})
+  (* ; ({exp=20n; positive=true}, {v=24846245577653162038756966;offset=-160}) -2^20  *)
+  ]
+
+
 let default_storage (constants : constants) : storage =
 
   let min_tick_state =
@@ -17,7 +93,7 @@ let default_storage (constants : constants) : storage =
     ; tick_cumulative_outside = 0
     ; fee_growth_outside = {x = { x128 = 0n } ; y = { x128 = 0n }}
     ; seconds_per_liquidity_outside = {x128 = 0n}
-    ; sqrt_price = half_bps_pow (-const_max_tick)
+    ; sqrt_price = half_bps_pow (-const_max_tick, default_ladder)
     } in
 
   let max_tick_state =
@@ -29,7 +105,7 @@ let default_storage (constants : constants) : storage =
     ; tick_cumulative_outside = 0
     ; fee_growth_outside = {x = { x128 = 0n } ; y = { x128 = 0n }}
     ; seconds_per_liquidity_outside = {x128 = 0n}
-    ; sqrt_price = half_bps_pow (int const_max_tick)
+    ; sqrt_price = half_bps_pow (int const_max_tick, default_ladder)
     } in
 
   let ticks = Big_map.literal [
@@ -38,7 +114,7 @@ let default_storage (constants : constants) : storage =
   ] in
 
   { liquidity = 0n
-  ; sqrt_price = half_bps_pow 0
+  ; sqrt_price = half_bps_pow (0, default_ladder)
   ; cur_tick_index = { i = 0 }
   ; cur_tick_witness  = { i = -const_max_tick }
   ; fee_growth = { x = { x128 = 0n }; y = { x128 = 0n } }
@@ -50,6 +126,7 @@ let default_storage (constants : constants) : storage =
   ; new_position_id = 0n
   ; operators = (Big_map.empty : operators)
   ; constants = constants
+  ; ladder = default_ladder
   }
 
 (* Identity contract using 'parameter' and 'storage'.

--- a/ligo/math.mligo
+++ b/ligo/math.mligo
@@ -5,7 +5,7 @@
 #else
 #define MATH_MLIGO
 
-type fixed_point = { v : nat ; offset : int }
+#include "types.mligo"
 
 [@inline] let fixed_point_mul (a : fixed_point) (b : fixed_point) : fixed_point =
     { v = a.v * b.v ; offset = a.offset + b.offset }
@@ -64,61 +64,24 @@ let rec stepped_shift_left (x, y : nat * nat) : nat =
         let new_x = Bitwise.shift_left x 256n in
         stepped_shift_left (new_x, abs (y - 256))
 
-(* TODO move ladders to a bigmap and load lazily *)
-let positive_ladder = [
-    {v=38687560557337355742483221n; offset=-85}; (* 2^0 *)
-    {v=38689494983725479307861971n; offset=-85};
-    {v=38693364126677775184793561n; offset=-85};
-    {v=38701103573421987005215721n; offset=-85};
-    {v=38716587111352494729706462n; offset=-85};
-    {v=38747572773653928660613512n; offset=-85};
-    {v=38809618513447185627569983n; offset=-85};
-    {v=38934008210058939100663682n; offset=-85};
-    {v=39183984934869404935943141n; offset=-85};
-    {v=39688763633815974521145659n; offset=-85};
-    {v=40717912888646086984030507n; offset=-85};
-    {v=42856962434838368098529959n; offset=-85};
-    {v=47478079282778087338933597n; offset=-85};
-    {v=29134438707490415855866100n; offset=-84};
-    {v=43882733799120415566608322n; offset=-84};
-    {v=49778031622173924435819796n; offset=-83};
-    {v=32025492072892644517427309n; offset=-80};
-    {v=53023938993515524338629870n; offset=-76};
-    {v=36338278329035183585718600n; offset=-66};
-    {v=34133361681864713959105863n; offset=-47}]
-    (* {v=30116777038798852995368017;offset=-9}]  2^20  *)
 
-let negative_ladder = [
-    {v=19341845997356488514015570n; offset=-84}; (* -2^0 *)
-    {v=2417609866154190654524678n; offset=-81};
-    {v=38677889876083546261210550n; offset=-85};
-    {v=38670155071614559132217310n; offset=-85};
-    {v=19327345051392939314248854n; offset=-84};
-    {v=19311889358453304431405214n; offset=-84};
-    {v=77124060166079386301517011n; offset=-86};
-    {v=38438828813936263312862610n; offset=-85};
-    {v=76387211720013513967242610n; offset=-86};
-    {v=75415686436335201065707301n; offset=-86};
-    {v=73509547540888574991368714n; offset=-86};
-    {v=17460146398643019245576278n; offset=-84};
-    {v=126085780994910985395717054n; offset=-87};
-    {v=102735988268212419722671870n; offset=-87};
-    {v=68208042073114503830679361n; offset=-87};
-    {v=60130046442422405275353178n; offset=-88};
-    {v=11682706336100247487260846n; offset=-88};
-    {v=56449132412055094618915006n; offset=-95};
-    {v=20592303012757789234393034n; offset=-103};
-    {v=1370156647050591448120178n; offset=-118}]
-    (* {v=24846245577653162038756966;offset=-160} : 2^20 *)
+let unsafe_ediv (x, y : nat * nat) : (nat * nat) =
+    match ediv x y with
+    | None -> (failwith internal_impossible_err : nat * nat)
+    | Some d -> d
 
-let rec half_bps_pow_rec ((tick, acc, ladder) : nat * fixed_point * (fixed_point list)) : fixed_point =
+
+let rec half_bps_pow_rec ((tick, acc, ladder_key, ladder) : nat * fixed_point * ladder_key * ladder) : fixed_point =
     if tick = 0n then
         acc
     else
-        let (half, rem) = match ediv tick 2n with | None -> (failwith internal_impossible_err : nat * nat) | Some d -> d in
-        match ladder with
-        | [] -> (failwith price_out_of_bounds_err : fixed_point)
-        | h :: t -> half_bps_pow_rec (half, (if rem = 0n then acc else fixed_point_mul h acc), t)
+        let (half, rem) = unsafe_ediv (tick, 2n) in
+        match Big_map.find_opt ladder_key ladder with
+        | None -> (failwith price_out_of_bounds_err : fixed_point)
+        | Some h ->
+            let new_acc = if rem = 0n then acc else fixed_point_mul h acc in
+            let new_ladder_key = {ladder_key with exp = ladder_key.exp + 1n} in
+            half_bps_pow_rec (half, new_acc, new_ladder_key, ladder)
 
 (*
   For a tick index `i`, calculate the corresponding `sqrt_price`:
@@ -126,44 +89,13 @@ let rec half_bps_pow_rec ((tick, acc, ladder) : nat * fixed_point * (fixed_point
   using the exponentiation by squaring method, where:
     bps = 0.0001
  *)
-let half_bps_pow (tick : int) : x80n =
-    let product = half_bps_pow_rec (abs tick, {v=1n;offset=0}, (if tick > 0  then positive_ladder  else negative_ladder)) in
+let half_bps_pow (tick, ladder : int * ladder) : x80n =
+    let product = half_bps_pow_rec (abs tick, {v=1n;offset=0}, {exp=0n;positive=(tick > 0)}, ladder) in
     let doffset = -80 - product.offset in
     if doffset > 0 then
         {x80 = stepped_shift_right (product.v, abs doffset)}
     else
         (* This branch should almost never happen, in general the price we get is not a round number. *)
         {x80 = stepped_shift_left (product.v, abs doffset)}
-
-(* ladder explanation
-
-relative error for each ladder element is  2^(-86)
-In the worst case, the product of all the mantissas is
-
-264282414466372656233620232085\
-891076152819178199188386987876\
-130399611230776317562564102356\
-510887554505841649869995115306\
-153657257592287884078198212867\
-452334369951588805003086042064\
-419487861191053453237580032868\
-756342299942389805587432570501\
-862667904215683136301357731738\
-924376078014888356296733854672\
-700413177506511695535173325976\
-383558174492550937991343710044\
-641323722927702345262447930316\
-774974009739628156118404725209\
-505333623465138071036374956137\
-115703347618301958744836243752\
-685553646224208937741458987598\
-9769554995549619185305600000
-
-A 1786 bit number.
-
-Also in the worse case, the product of all the error terms is (1 + total_err) with |total_err| < 2^(-81)
-This ensures that the tick index can be matched to a square root price with over 80 bits of precision
-
-*)
 
 #endif

--- a/ligo/types.mligo
+++ b/ligo/types.mligo
@@ -293,6 +293,13 @@ type constants = {
     y_token_address : address ;
 }
 
+
+(* See defaults.mligo for more info *)
+type fixed_point = { v : nat ; offset : int }
+type ladder_key = { exp : nat ; positive : bool }
+type ladder = (ladder_key, fixed_point) big_map
+
+
 type storage = {
     (* Virtual liquidity, the value L for which the curve locally looks like x * y = L^2. *)
     liquidity : nat ;
@@ -337,6 +344,9 @@ type storage = {
 
     (* Constants for options that are settable at origination *)
     constants : constants ;
+
+    (* Exponents ladder for the calculation of 'half_bps_pow' *)
+    ladder : ladder;
 }
 
 (* Entrypoints types *)


### PR DESCRIPTION
## Description

Problem: the contract uses two latters of exponents for the calculation
of powers. These ladders however are part of the contract code and
as such are quite expensive for size and gas cost.

Solution: move the two ladders to a single big_map in the storage.

## Related issue(s)

Resolves part of TCFMM-29

## :white_check_mark: Checklist for your Pull Request

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [Specification](../tree/master/docs/specification.md)
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

[//]: # (Update link to style guide if necesary or remove if it's not present)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
