### PR TITLE
[TCFMM-40] Impose granularity in tick initialization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,7 @@ $(OUT)/storage_%.tz : y_token_id = 0
 $(OUT)/storage_%.tz : x_token_address = KT1PWx2mnDueood7fEmfbBDKx1D9BAnnXitn
 $(OUT)/storage_%.tz : y_token_address = KT1PWx2mnDueood7fEmfbBDKx1D9BAnnXitn
 $(OUT)/storage_%.tz : init_cumulatives_buffer_extra_slots = 0
+$(OUT)/storage_%.tz : tick_spacing = 1
 $(OUT)/storage_%.tz: $(shell find ligo -name '*.mligo')
 	# ============== Compiling default LIGO storage ============== #
 	$(BUILD_STORAGE) ligo/defaults.mligo entrypoint "default_storage( \
@@ -96,6 +97,7 @@ $(OUT)/storage_%.tz: $(shell find ligo -name '*.mligo')
 			; y_token_id = $(y_token_id)n \
 			; x_token_address = (\"$(x_token_address)\" : address) \
 			; y_token_address = (\"$(y_token_address)\" : address) \
+			; tick_spacing = $(tick_spacing)n \
 	    }) ($(init_cumulatives_buffer_extra_slots)n)" \
         --output-file $@
 

--- a/docs/compilation.md
+++ b/docs/compilation.md
@@ -60,7 +60,8 @@ make out/storage_default.tz \
   x_token_id=0 \
   y_token_id=0 \
   x_token_address=KT1PWx2mnDueood7fEmfbBDKx1D9BAnnXitn \
-  y_token_address=KT1PWx2mnDueood7fEmfbBDKx1D9BAnnXitn
+  y_token_address=KT1PWx2mnDueood7fEmfbBDKx1D9BAnnXitn \
+  tick_spacing=1
 ```
 
 At the very least, you'll probably want to change the tokens' contract address.

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -32,6 +32,7 @@ Here is a summary of all the error codes thrown by the contract.
 | 110 | `observe_future_timestamp_err` | Some of the timestamps passed to the `observe` entrypoint are yet in the future. |
 | 111 | `tick_order_err` | When setting a new position, `upper_tick_index` must be strictly greater than `lower_tick_index`. When observing cumulative values at range, `upper_tick_index` must be greater or equal than `lower_tick_index`. |
 | 112 | `position_liquidity_below_zero_err` | Liquidity of a position went below zero. |
+| 113 | `incorrect_tick_spacing_err` | Tick indexes must be a multiple of the tick spacing. |
 
 
 #### Contract Configuration Error Codes

--- a/haskell/src/SegCFMM/Errors.hs
+++ b/haskell/src/SegCFMM/Errors.hs
@@ -66,6 +66,10 @@ tickOrderErr = 111
 positionLiquidityBelowZeroErr :: Natural
 positionLiquidityBelowZeroErr = 112
 
+-- | Tick indexes must be a multiple of the tick spacing.
+incorrectTickSpacingErr :: Natural
+incorrectTickSpacingErr = 113
+
 
 ----------------------------------------------------------------------------
 -- Contract Configuration Error Codes

--- a/haskell/src/SegCFMM/Types.hs
+++ b/haskell/src/SegCFMM/Types.hs
@@ -465,6 +465,7 @@ data Constants = Constants
   , cYTokenId :: FA2.TokenId
   , cXTokenAddress :: Address
   , cYTokenAddress :: Address
+  , cTickSpacing :: Natural
   }
   deriving stock Eq
 

--- a/ligo/errors.mligo
+++ b/ligo/errors.mligo
@@ -53,6 +53,9 @@
 (* Liquidity of a position went below zero. *)
 [@inline] let position_liquidity_below_zero_err = 112n
 
+(* Tick indexes must be a multiple of the tick spacing. *)
+[@inline] let incorrect_tick_spacing_err = 113n
+
 
 
 // ---------------------------------------------------------------------------

--- a/ligo/helpers.mligo
+++ b/ligo/helpers.mligo
@@ -114,4 +114,11 @@ let get_last_cumulatives (buffer : timed_cumulatives_buffer) : timed_cumulatives
     get_registered_cumulatives_unsafe buffer buffer.last
 
 
+(* Ensure tick index is multiple of tick spacing. *)
+[@inline]
+let check_multiple_of_tick_spacing (tick_index, storage: tick_index * storage) : unit =
+    if (tick_index.i mod storage.constants.tick_spacing = 0n)
+        then unit
+        else failwith incorrect_tick_spacing_err
+
 #endif

--- a/ligo/main.mligo
+++ b/ligo/main.mligo
@@ -220,6 +220,8 @@ let update_cur_tick_witness (s : storage) (tick_index : tick_index) : storage =
 
 let set_position (s : storage) (p : set_position_param) : result =
     let _: unit = check_deadline p.deadline in
+    let _: unit = check_multiple_of_tick_spacing (p.lower_tick_index, s) in
+    let _: unit = check_multiple_of_tick_spacing (p.upper_tick_index, s) in
     let _: unit = if p.lower_tick_index >= p.upper_tick_index then failwith tick_order_err else unit in
 
     // Creating position with 0 liquidity must result in no changes being made

--- a/ligo/types.mligo
+++ b/ligo/types.mligo
@@ -293,6 +293,7 @@ type constants = {
     y_token_id : token_id ;
     x_token_address : address ;
     y_token_address : address ;
+    tick_spacing : nat ;
 }
 
 

--- a/scripts/generate_error_code.hs
+++ b/scripts/generate_error_code.hs
@@ -87,6 +87,9 @@ invalidInputErrors = errorsEnumerate 100
   , "position_liquidity_below_zero_err"
       :? "Liquidity of a position went below zero."
 
+  , "incorrect_tick_spacing_err"
+      :? "Tick indexes must be a multiple of the tick spacing."
+
   ]
 
 invalidConfigErrors :: [ErrorItem]


### PR DESCRIPTION


[//]: # (This is a template of a pull request template.)
[//]: # (You should modify it considering specifics of a particular repository and put it there.)
[//]: # (Comments like this are meta-comments, they shouldn't be present in the final template.)
[//]: # (Comments starting with '<!---' are intended to stay in the final template.)

[//]: # (Keep in mind that it's only a template which contains items relevant to almost all conceivable repository.)
[//]: # (There can be other important items relevant to your repository that you can add here.)

## Description
Problem: There is the possibility that cost for swaps will get too
high when many nearby ticks are initialized, because we'll need to
traverse many of them. To prevent this from happening we should impose
a granularity to which ticks can be initialized.

In other words there should be a settable constant equivalent to the
`tickSpacing` in the whitepaper that establishes a number `n` so that
ticks can only be initialized if they are a multiple of `n`.

Solution: Add a constant for spacing between ticks, add tests to cover.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

[//]: # (Here you can add a link to the corresponding issue tracker, e. g. https://issues.serokell.io/issue/AD-)
[//]: # (For GitHub/GitLab issues it is better to use just hash symbol or exclamation mark as it is more resistant to repo movements)
[//]: # (In this case please also prefix the link with "Resolves" keyword)
[//]: # (See https://docs.gitlab.com/ee/user/project/issues/managing_issues.html#closing-issues-automatically)
[//]: # (See https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords)
## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves TCFMM-40

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [Specification](../tree/master/docs/specification.md)
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

[//]: # (Update link to style guide if necesary or remove if it's not present)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
