### PR TITLE
[TCFMM-42] Enable network tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,22 +1,40 @@
 # SPDX-FileCopyrightText: 2021 Arthur Breitman
 # SPDX-License-Identifier: LicenseRef-MIT-Arthur-Breitman
 
+.scheduled: &scheduled build.source == "schedule"
+.not-scheduled: &not-scheduled build.source != "schedule"
+
+.network-tests: &network-tests
+  commands:
+    - nix-build ci.nix -A packages.segmented-cfmm.tests.segmented-cfmm-test
+    - nix run -f ci.nix tezos-client -c ./result/bin/segmented-cfmm-test
+          --nettest-mode=only-network
+          --nettest-data-dir "$(mktemp -d --tmpdir="$PWD")"
+  retry:
+    automatic:
+      limit: 1
+  timeout_in_minutes: 360
+
 steps:
   - label: hlint
+    if: *not-scheduled
     commands:
     - nix run -f ci.nix pkgs.hlint -c
         ./scripts/lint.sh
 
   - label: reuse lint
+    if: *not-scheduled
     commands:
     - nix run -f ci.nix pkgs.reuse -c
         reuse lint
 
   - label: check trailing whitespace
+    if: *not-scheduled
     commands:
     - .buildkite/check-trailing-whitespace.sh
 
   - label: xrefcheck
+    if: *not-scheduled
     commands:
     - nix run -f ci.nix xrefcheck -c xrefcheck
     retry:
@@ -24,11 +42,13 @@ steps:
         limit: 1
 
   - label: check cabal files
+    if: *not-scheduled
     commands:
     - nix run -f ci.nix stack2cabal pkgs.diffutils -c ./scripts/ci/validate-cabal-files.sh
 
   - label: build-ligo
     key: build-ligo
+    if: *not-scheduled
     commands:
       - nix-build ci.nix -A build-ligo -o ./ligo-out/
     artifact_paths:
@@ -36,18 +56,54 @@ steps:
 
   - label: build-haskell
     key: build-haskell
+    if: *not-scheduled
     commands:
     - nix-build ci.nix -A all-components
 
   - label: ligo-test
-    key: ligo-test
-    depends_on:
-      - build-haskell
+    if: *not-scheduled
     commands:
-    - nix-build ci.nix -A packages.segmented-cfmm.tests.segmented-cfmm-test
-    - ./result/bin/segmented-cfmm-test --nettest-mode=disable-network
+      - nix-build ci.nix -A packages.segmented-cfmm.tests.segmented-cfmm-test
+      - ./result/bin/segmented-cfmm-test --nettest-mode=disable-network
+
+  - label: ligo-test-local-chain-010
+    if: *not-scheduled
+    <<: *network-tests
+    env:
+      # this key is defined in local-chain bootstrap accounts list in
+      # https://github.com/serokell/aquarius-infra/blob/master/servers/albali/chain.nix
+      TASTY_NETTEST_IMPORT_SECRET_KEY: "unencrypted:edsk42cYfuawC5i3PmuS3Lq73pAzgrJyVNcv9CXQspM2dG4M9QMpeS"
+      TASTY_NETTEST_NODE_ENDPOINT: "http://localhost:8733"
+
+  - label: ligo-test-local-chain-011
+    if: *not-scheduled
+    <<: *network-tests
+    env:
+      # this key is defined in local-chain bootstrap accounts list in
+      # https://github.com/serokell/aquarius-infra/blob/master/servers/albali/chain.nix
+      TASTY_NETTEST_IMPORT_SECRET_KEY: "unencrypted:edsk42cYfuawC5i3PmuS3Lq73pAzgrJyVNcv9CXQspM2dG4M9QMpeS"
+      TASTY_NETTEST_NODE_ENDPOINT: "http://localhost:8734"
+
+  - label: ligo-test-granadanet-scheduled
+    if: *scheduled
+    <<: *network-tests
+    env:
+      # Note that testnet moneybag can run out of tz. If this happened, someone should transfer it some
+      # more tz, its address: tz1Nbp1gNPMzn9MB9ZhBnfsajsaQBLYScdd5
+      TASTY_NETTEST_IMPORT_SECRET_KEY: "unencrypted:edsk48WyaFHvsqLYQBrCBiRUdnPa7VduZbePo5UAbyMJRN8Eob5PvL"
+      TASTY_NETTEST_NODE_ENDPOINT: "https://granada.testnet.tezos.serokell.team"
+
+  - label: ligo-test-hangzhounet-scheduled
+    if: *scheduled
+    <<: *network-tests
+    env:
+      # Note that testnet moneybag can run out of tz. If this happened, someone should transfer it some
+      # more tz, its address: tz1Nbp1gNPMzn9MB9ZhBnfsajsaQBLYScdd5
+      TASTY_NETTEST_IMPORT_SECRET_KEY: "unencrypted:edsk48WyaFHvsqLYQBrCBiRUdnPa7VduZbePo5UAbyMJRN8Eob5PvL"
+      TASTY_NETTEST_NODE_ENDPOINT: "https://hangzhou.testnet.tezos.serokell.team"
 
   - label: check typescript api
+    if: *not-scheduled
     depends_on:
       - build-ligo
       - build-haskell
@@ -56,6 +112,7 @@ steps:
 
 
   - label: typescript-build
+    if: *not-scheduled
     depends_on:
       - build-ligo
       - build-haskell
@@ -63,12 +120,18 @@ steps:
     - nix-build ci.nix -A build-typescript --arg release false
 
   - label: weeder
+    if: *not-scheduled
     depends_on: build-haskell
     commands:
     - nix-build ci.nix -A weeder-script
     - ./result
 
   - label: haddock
+    if: *not-scheduled
     depends_on: build-haskell
     commands:
     - nix-build ci.nix -A haddock --no-out-link
+
+notify:
+  - email: "tezos-alerts@serokell.io"
+    if: build.state == "failed" && build.source == "schedule"

--- a/README.md
+++ b/README.md
@@ -36,19 +36,13 @@ For more information and instructions on how to run it locally, please refer to
 
 ## Testing
 
-This repository includes several property and unit tests, implemented with the
+This repository includes several property-based and example-based tests, implemented with the
 [cleveland test framework](https://gitlab.com/morley-framework/morley/-/tree/master/code/cleveland)
 in the [haskell/test](haskell/test) directory.
 
-In order to run these tests you'll need the `stack` tool installed, see
-[The Haskell Tool Stack](https://docs.haskellstack.org/en/stable/README/)
-tutorial for instructions on how to obtain it.
+For more information and instructions on how to run the tests, please refer to
+[its documentation](haskell/README.md).
 
-With that, the simplest way to run these tests is to execute the
-```bash
-make test
-```
-command.
 
 ## Python
 

--- a/haskell/README.md
+++ b/haskell/README.md
@@ -1,3 +1,51 @@
 # Segmented CFMM Tests and utilities
 
-TODO: describe the haskell app and testing.
+This folder includes:
+* a test suite, implemented with the
+[cleveland test framework](https://gitlab.com/morley-framework/morley/-/tree/master/code/cleveland)
+in the [./test](./test) directory
+* a haskell CLI application with a few useful commands
+
+
+## Running the tests
+
+In order to run these tests you'll need the `stack` tool installed, see
+[The Haskell Tool Stack](https://docs.haskellstack.org/en/stable/README/)
+tutorial for instructions on how to install it.
+
+The most straightforward way to run them is to execute the following command at the repository's root:
+
+```bash
+# Run emulator tests
+make test
+```
+
+This will run all tests, example-based and property-based, on the morley emulator.
+
+### Network tests
+
+To run network tests as well, use:
+
+```bash
+# Run emulator and network tests
+make test TEST_ARGUMENTS='--nettest-mode all'
+
+# Run network tests only
+make test TEST_ARGUMENTS='--nettest-mode only-network'
+```
+
+Network tests:
+* require having [`tezos-client`](https://github.com/serokell/tezos-packaging) installed and;
+* assume an implicit account with alias "nettest" has been registered and has sufficient tez to run the tests.
+
+They will be run against whatever chain `tezos-client` is configured to use.
+To use a different chain, use the `--nettest-node-endpoint`/`-E` option.
+
+For more configuration options, see `make test TEST_ARGUMENTS='--help'` .
+
+## CLI App
+
+This app contains some commands used to generate the contract's TZIP-16 metadata and typescript bindings.
+The app is only used internally to implement other `MAKE` commands
+(described [here](../README.md) and [here](../typescript/segmented-cfmm/README.md))
+and end-users shouldn't need to use it directly.

--- a/haskell/package.yaml
+++ b/haskell/package.yaml
@@ -31,6 +31,7 @@ verbatim:
 
 default-extensions:
   - AllowAmbiguousTypes
+  - ApplicativeDo
   - BangPatterns
   - BlockArguments
   - ConstraintKinds

--- a/haskell/segmented-cfmm.cabal
+++ b/haskell/segmented-cfmm.cabal
@@ -48,6 +48,7 @@ library
       src
   default-extensions:
       AllowAmbiguousTypes
+      ApplicativeDo
       BangPatterns
       BlockArguments
       ConstraintKinds
@@ -120,6 +121,7 @@ executable segmented-cfmm
       app
   default-extensions:
       AllowAmbiguousTypes
+      ApplicativeDo
       BangPatterns
       BlockArguments
       ConstraintKinds
@@ -214,6 +216,7 @@ test-suite segmented-cfmm-test
       test
   default-extensions:
       AllowAmbiguousTypes
+      ApplicativeDo
       BangPatterns
       BlockArguments
       ConstraintKinds

--- a/haskell/test/Test/FA2.hs
+++ b/haskell/test/Test/FA2.hs
@@ -80,44 +80,44 @@ test_FA2_positions =
           allPositions = map fst positionsList
 
       -- assign operators
-      forM_ operatedPositions $ \positionId ->
-        withSender ownerOnly $
+      withSender ownerOnly $ inBatch do
+        for_ operatedPositions $ \positionId ->
           updateOperator cfmm ownerOnly ownerAndOperator positionId True
 
       -- the 'ownerAndOperator' can transfer its own positions
-      forM_ ownerPositions $ \positionId ->
-        withSender ownerAndOperator $
+      withSender ownerAndOperator $ inBatch do
+        for_ ownerPositions $ \positionId ->
           transferToken' cfmm ownerAndOperator finalOwner positionId
 
       -- the 'ownerAndOperator' cannot transfer positions it's not operator of
-      forM_ ownedOnlyPositions $ \positionId ->
-        expectCustomError_ #fA2_NOT_OPERATOR $
-          withSender ownerAndOperator $
+      withSender ownerAndOperator $
+        for_ ownedOnlyPositions $ \positionId ->
+          expectCustomError_ #fA2_NOT_OPERATOR $
             transferToken' cfmm ownerOnly finalOwner positionId
 
-      forM_ finalOwnerPositions $ \positionId ->
-        expectCustomError_ #fA2_NOT_OPERATOR $
-          withSender ownerAndOperator $
+      withSender ownerAndOperator $
+        for_ finalOwnerPositions $ \positionId ->
+          expectCustomError_ #fA2_NOT_OPERATOR $
             transferToken' cfmm finalOwner ownerOnly positionId
 
       -- the 'ownerAndOperator' can transfer positions it's operator of
-      forM_ operatedPositions $ \positionId ->
-        withSender ownerAndOperator $
+      withSender ownerAndOperator $ inBatch do
+        for_ operatedPositions $ \positionId ->
           transferToken' cfmm ownerOnly finalOwner positionId
 
       -- the 'ownerOnly' can no longer transfer the operated positions
-      forM_ operatedPositions $ \positionId ->
-        expectCustomError #fA2_INSUFFICIENT_BALANCE (#required .! 1, #present .! 0) $
-          withSender ownerOnly $
+      withSender ownerOnly $
+        for_ operatedPositions $ \positionId ->
+          expectCustomError #fA2_INSUFFICIENT_BALANCE (#required .! 1, #present .! 0) $
             transferToken' cfmm ownerOnly finalOwner positionId
 
       -- the 'ownerOnly' can still transfer the owned positions
-      forM_ ownedOnlyPositions $ \positionId ->
-        withSender ownerOnly $
+      withSender ownerOnly $ inBatch do
+        for_ ownedOnlyPositions $ \positionId ->
           transferToken' cfmm ownerOnly finalOwner positionId
 
       -- in the end all positions should be owned by 'finalOwner'
-      forM_ allPositions $ \positionId -> do
+      for_ allPositions $ \positionId -> do
         balanceOf (TokenInfo positionId cfmm) ownerAndOperator @@== 0
         balanceOf (TokenInfo positionId cfmm) ownerOnly        @@== 0
         balanceOf (TokenInfo positionId cfmm) finalOwner       @@== 1

--- a/haskell/test/Test/FA2.hs
+++ b/haskell/test/Test/FA2.hs
@@ -117,7 +117,9 @@ test_FA2_positions =
           transferToken' cfmm ownerOnly finalOwner positionId
 
       -- in the end all positions should be owned by 'finalOwner'
-      for_ allPositions $ \positionId -> do
-        balanceOf (TokenInfo positionId cfmm) ownerAndOperator @@== 0
-        balanceOf (TokenInfo positionId cfmm) ownerOnly        @@== 0
-        balanceOf (TokenInfo positionId cfmm) finalOwner       @@== 1
+      balanceConsumers <- originateBalanceConsumers $ allPositions <&> \positionId -> TokenInfo positionId cfmm
+      balances <- balancesOfMany balanceConsumers (ownerAndOperator, ownerOnly, finalOwner)
+      for_ balances \(ownerAndOperatorBalance, ownerOnlyBalance, finalOwnerBalance) -> do
+        ownerAndOperatorBalance @== 0
+        ownerOnlyBalance        @== 0
+        finalOwnerBalance       @== 1

--- a/haskell/test/Test/FA2/BalanceOf.hs
+++ b/haskell/test/Test/FA2/BalanceOf.hs
@@ -79,12 +79,17 @@ test_multiple_positions =
     nonOwner2 <- newAddress auto
     transferMoney owner1 10_e6
     cfmm <- fst <$> prepareSomeSegCFMM [owner1, owner2, owner3, nonOwner1] defaultTokenTypes def
-    withSender owner1 $ setPosition cfmm liquidity (-20, -15)   -- TokenId 0
-    withSender owner1 $ setPosition cfmm liquidity (-10, 1)     -- TokenId 1
-    withSender owner1 $ setPosition cfmm liquidity (6, 17)      -- TokenId 2
-    withSender owner2 $ setPosition cfmm liquidity (-10, 15)    -- TokenId 3
-    withSender owner3 $ setPosition cfmm liquidity (-10, 15)    -- TokenId 4
-    withSender owner3 $ setPosition cfmm liquidity (-1, 8)      -- TokenId 5
+    withSender owner1 $ inBatch do
+      setPosition cfmm liquidity (-20, -15)   -- TokenId 0
+      setPosition cfmm liquidity (-10, 1)     -- TokenId 1
+      setPosition cfmm liquidity (6, 17)      -- TokenId 2
+      pure ()
+    withSender owner2 do
+      setPosition cfmm liquidity (-10, 15)    -- TokenId 3
+    withSender owner3 $ inBatch do
+      setPosition cfmm liquidity (-10, 15)    -- TokenId 4
+      setPosition cfmm liquidity (-1, 8)      -- TokenId 5
+      pure ()
 
     let tokenIds = map FA2.TokenId [0..5]
 

--- a/haskell/test/Test/FA2/BalanceOf.hs
+++ b/haskell/test/Test/FA2/BalanceOf.hs
@@ -71,12 +71,13 @@ test_exisiting_position =
 
 test_multiple_positions :: TestTree
 test_multiple_positions =
-  nettestScenarioOnEmulatorCaps "balance_of can handle multiple owners and positions" do
+  nettestScenarioCaps "balance_of can handle multiple owners and positions" do
     owner1 <- newAddress auto
     owner2 <- newAddress auto
     owner3 <- newAddress auto
     nonOwner1 <- newAddress auto
     nonOwner2 <- newAddress auto
+    transferMoney owner1 10_e6
     cfmm <- fst <$> prepareSomeSegCFMM [owner1, owner2, owner3, nonOwner1] defaultTokenTypes def
     withSender owner1 $ setPosition cfmm liquidity (-20, -15)   -- TokenId 0
     withSender owner1 $ setPosition cfmm liquidity (-10, 1)     -- TokenId 1

--- a/haskell/test/Test/FA2/BalanceOf.hs
+++ b/haskell/test/Test/FA2/BalanceOf.hs
@@ -1,5 +1,6 @@
 -- SPDX-FileCopyrightText: 2021 Arthur Breitman
 -- SPDX-License-Identifier: LicenseRef-MIT-Arthur-Breitman
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.FA2.BalanceOf
   ( test_unknown_position
@@ -18,6 +19,8 @@ import qualified Lorentz.Contracts.Spec.FA2Interface as FA2
 import Morley.Nettest
 import Morley.Nettest.Tasty
 
+import Fmt (Buildable, build, tupleF)
+import Lorentz (Address)
 import Test.SegCFMM.Contract
 import Test.Util
 
@@ -30,16 +33,21 @@ test_unknown_position =
     owner <- newAddress auto
     cfmm <- fst <$> prepareSomeSegCFMM [owner] defaultTokenTypes def
 
-    expectCustomError_ #fA2_TOKEN_UNDEFINED $ balanceOf (TokenInfo (FA2.TokenId 0) cfmm) owner
-    expectCustomError_ #fA2_TOKEN_UNDEFINED $ balanceOf (TokenInfo (FA2.TokenId 1) cfmm) owner
-    expectCustomError_ #fA2_TOKEN_UNDEFINED $ balanceOf (TokenInfo (FA2.TokenId 8) cfmm) owner
+    let balanceOf' tokenId = do
+          balanceConsumer <- originateBalanceConsumer (TokenInfo tokenId cfmm)
+          balanceOf balanceConsumer owner
+
+    expectCustomError_ #fA2_TOKEN_UNDEFINED $ balanceOf' $ FA2.TokenId 0
+    expectCustomError_ #fA2_TOKEN_UNDEFINED $ balanceOf' $ FA2.TokenId 1
+    expectCustomError_ #fA2_TOKEN_UNDEFINED $ balanceOf' $ FA2.TokenId 8
 
 test_empty_requests :: TestTree
 test_empty_requests =
   nettestScenarioOnEmulatorCaps "balance_of accepts empty requests" do
     owner <- newAddress auto
     cfmm <- fst <$> prepareSomeSegCFMM [owner] defaultTokenTypes def
-    balancesOf cfmm [] owner @@== []
+    balanceConsumer <- originateBalanceConsumer (TokenInfo (FA2.TokenId 0) cfmm)
+    balancesOfMany [balanceConsumer] ([] :: [Address]) @@== one []
 
 test_owned_position :: TestTree
 test_owned_position =
@@ -47,7 +55,9 @@ test_owned_position =
     owner <- newAddress auto
     cfmm <- fst <$> prepareSomeSegCFMM [owner] defaultTokenTypes def
     withSender owner $ setPosition cfmm liquidity (-10, 10)
-    balanceOf (TokenInfo (FA2.TokenId 0) cfmm) owner @@== 1
+
+    balanceConsumer <- originateBalanceConsumer (TokenInfo (FA2.TokenId 0) cfmm)
+    balanceOf balanceConsumer owner @@== 1
 
 test_unowned_position :: TestTree
 test_unowned_position =
@@ -57,7 +67,8 @@ test_unowned_position =
     cfmm <- fst <$> prepareSomeSegCFMM [owner, nonOwner] defaultTokenTypes def
     withSender owner $ setPosition cfmm liquidity (-10, 15)
 
-    balanceOf (TokenInfo (FA2.TokenId 0) cfmm) nonOwner @@== 0
+    balanceConsumer <- originateBalanceConsumer (TokenInfo (FA2.TokenId 0) cfmm)
+    balanceOf balanceConsumer nonOwner @@== 0
 
 test_exisiting_position :: TestTree
 test_exisiting_position =
@@ -67,7 +78,8 @@ test_exisiting_position =
     withSender owner $ setPosition cfmm liquidity (10, 15)
 
     nonOwner <- newAddress auto
-    balanceOf (TokenInfo (FA2.TokenId 0) cfmm) nonOwner @@== 0
+    balanceConsumer <- originateBalanceConsumer (TokenInfo (FA2.TokenId 0) cfmm)
+    balanceOf balanceConsumer nonOwner @@== 0
 
 test_multiple_positions :: TestTree
 test_multiple_positions =
@@ -91,10 +103,29 @@ test_multiple_positions =
       setPosition cfmm liquidity (-1, 8)      -- TokenId 5
       pure ()
 
-    let tokenIds = map FA2.TokenId [0..5]
+    -- Originating all 6 contracts in one batch may go over the gas limit,
+    -- so we do it in 2 batches of 3 instead.
+    (bc0, bc1, bc2) <- originateBalanceConsumers
+      ( TokenInfo (FA2.TokenId 0) cfmm
+      , TokenInfo (FA2.TokenId 1) cfmm
+      , TokenInfo (FA2.TokenId 2) cfmm
+      )
+    (bc3, bc4, bc5) <- originateBalanceConsumers
+      ( TokenInfo (FA2.TokenId 3) cfmm
+      , TokenInfo (FA2.TokenId 4) cfmm
+      , TokenInfo (FA2.TokenId 5) cfmm
+      )
 
-    balancesOf cfmm tokenIds owner1    @@== [1, 1, 1, 0, 0, 0]
-    balancesOf cfmm tokenIds owner2    @@== [0, 0, 0, 1, 0, 0]
-    balancesOf cfmm tokenIds owner3    @@== [0, 0, 0, 0, 1, 1]
-    balancesOf cfmm tokenIds nonOwner1 @@== [0, 0, 0, 0, 0, 0]
-    balancesOf cfmm tokenIds nonOwner2 @@== [0, 0, 0, 0, 0, 0]
+    (balancesPosition0, balancesPosition1, balancesPosition2)
+      <- balancesOfMany (bc0, bc1, bc2) (owner1, owner2, owner3, nonOwner1, nonOwner2)
+    (balancesPosition3, balancesPosition4, balancesPosition5)
+      <- balancesOfMany (bc3, bc4, bc5) (owner1, owner2, owner3, nonOwner1, nonOwner2)
+
+    balancesPosition0 @== (1, 0, 0, 0, 0)
+    balancesPosition1 @== (1, 0, 0, 0, 0)
+    balancesPosition2 @== (1, 0, 0, 0, 0)
+    balancesPosition3 @== (0, 1, 0, 0, 0)
+    balancesPosition4 @== (0, 0, 1, 0, 0)
+    balancesPosition5 @== (0, 0, 1, 0, 0)
+
+instance (Buildable a, Buildable b, Buildable c, Buildable d, Buildable e) => Buildable (a, b, c, d, e) where build = tupleF

--- a/haskell/test/Test/Mining.hs
+++ b/haskell/test/Test/Mining.hs
@@ -47,7 +47,8 @@ test_BasicWorkflow =
     let miningRewardTokenId = FA2.TokenId 10
     miningRewardTokenContract <- originateFA2 [rewardGiver] miningRewardTokenId
     let miningRewardToken = FA2Token (toAddress miningRewardTokenContract) miningRewardTokenId
-    let getRewardOf = balanceOf (TokenInfo miningRewardTokenId miningRewardTokenContract)
+    rewardBalanceConsumer <- originateBalanceConsumer (TokenInfo miningRewardTokenId miningRewardTokenContract)
+    let getRewardOf = balanceOf rewardBalanceConsumer
 
     -- Prepare the contracts
     (cfmm, _) <- prepareSomeSegCFMM [liquidityProvider] tokenTypes def

--- a/haskell/test/Test/Position.hs
+++ b/haskell/test/Test/Position.hs
@@ -113,8 +113,7 @@ test_adding_liquidity_twice =
     let liquidityDelta = 1_e5
     liquidityProvider <- newAddress auto
     let accounts = [liquidityProvider]
-    x <- originateTokenContract accounts (fst tokenTypes) (FA2.TokenId 0)
-    y <- originateTokenContract accounts (snd tokenTypes) (FA2.TokenId 1)
+    (x, y) <- originateTokenContracts accounts ((fst tokenTypes, FA2.TokenId 0), (snd tokenTypes, FA2.TokenId 1))
     (cfmm1, _) <- prepareSomeSegCFMM accounts tokenTypes def { opTokens = Just (x, y) }
     (cfmm2, _) <- prepareSomeSegCFMM accounts tokenTypes def { opTokens = Just (x, y) }
 

--- a/haskell/test/Test/RangeOracles.hs
+++ b/haskell/test/Test/RangeOracles.hs
@@ -38,7 +38,7 @@ test_CornerCases = testGroup "Corner cases"
         call cfmm (Call @"Snapshot_cumulatives_inside") $
           SnapshotCumulativesInsideParam (TickIndex (-10)) (TickIndex 100) (toContractRef consumer)
 
-  , nettestScenarioOnEmulatorCaps "Asking at uninitialized tick causes an error" do
+  , nettestScenarioOnEmulatorCaps "Asking at empty range returns zeros" do
       alice <- newAddress "alice"
       (cfmm, _) <- prepareSomeSegCFMM [alice] defaultTokenTypes def
 
@@ -52,7 +52,7 @@ test_CornerCases = testGroup "Corner cases"
 
       getStorage consumer @@== [CumulativesInsideSnapshot 0 (X 0) 0]
 
-  , nettestScenarioOnEmulatorCaps "Asking at uninitialized tick causes an error" do
+  , nettestScenarioOnEmulatorCaps "Asking at reversed range causes an error" do
       alice <- newAddress "alice"
       (cfmm, _) <- prepareSomeSegCFMM [alice] defaultTokenTypes def
 

--- a/haskell/test/Test/SegCFMM/Contract.hs
+++ b/haskell/test/Test/SegCFMM/Contract.hs
@@ -7,6 +7,7 @@ module Test.SegCFMM.Contract
   ( TokenType (..)
   , xTokenTypes
   , yTokenTypes
+  , allTokenTypeCombinations
   , defaultTokenTypes
   , segCFMMContract
   ) where
@@ -25,6 +26,9 @@ data TokenType = FA12 | FA2 | CTEZ
 xTokenTypes, yTokenTypes :: [TokenType]
 xTokenTypes = [FA2, FA12]
 yTokenTypes = [FA2, FA12, CTEZ]
+
+allTokenTypeCombinations :: [(TokenType, TokenType)]
+allTokenTypeCombinations = (,) <$> xTokenTypes <*> yTokenTypes
 
 -- | An arbitrary pair of token types.
 -- Tests whose outcome does not depend on the token types, can use this default pair.

--- a/haskell/test/Test/Util.hs
+++ b/haskell/test/Test/Util.hs
@@ -521,10 +521,9 @@ validDeadline = [timestampQuote| 20021-01-01T00:00:00Z |]
 -- the cumulative buffers are filled every second.
 advanceSecs :: MonadNettest caps base m => Natural -> [ContractHandler Parameter st] -> m ()
 advanceSecs n cfmms = do
-  consumer <- originateSimple @[CumulativesValue] "advance-secs-consumer" [] contractConsumer
   for_ [1..n] \_ -> do
     advanceTime (sec 1)
-    for_ cfmms \cfmm -> call cfmm (Call @"Observe") $ mkView [] consumer
+    for_ cfmms \cfmm -> call cfmm (Call @"Increase_observation_count") 0
 
 -- | Converts a michelson doubly linked list (encoded as a big_map) to a list.
 -- The linked list is traversed starting from `minTickIndex` and

--- a/haskell/test/Test/Util.hs
+++ b/haskell/test/Test/Util.hs
@@ -248,7 +248,7 @@ balancesOf fa2 tokenIds account = do
 
 -- | Update a single operator for an FA2 contract.
 updateOperator
-  :: (HasCallStack, MonadNettest caps base m, FA2.ParameterC param)
+  :: (HasCallStack, MonadOps m, FA2.ParameterC param)
   => ContractHandler param storage
   -> Address     -- ^ owner
   -> Address     -- ^ operator
@@ -262,7 +262,7 @@ updateOperator fa2 opOwner opOperator opTokenId doAdd = do
 
 -- | Update operators for an FA2 contract.
 updateOperators
-  :: (HasCallStack, MonadNettest caps base m, FA2.ParameterC param)
+  :: (HasCallStack, MonadOps m, FA2.ParameterC param)
   => ContractHandler param storage
   -> FA2.UpdateOperatorsParam
   -> m ()
@@ -350,7 +350,7 @@ prepareSomeSegCFMM accounts (xTokenType, yTokenType) (OriginationParams tokensIn
   cfmm <- originateSimple "cfmm" initialStorage' $ segCFMMContract xTokenType yTokenType
 
   for_ accounts $ \account ->
-    withSender account do
+    withSender account $ inBatch do
       for_ [x, y] \case
         TokenInfo_12 tokenAddr -> call tokenAddr (Call @"Approve") (#spender .! toAddress cfmm, #value .! defaultBalance)
         TokenInfo tokenId tokenAddr -> updateOperator tokenAddr account (toAddress cfmm) tokenId True

--- a/haskell/test/Test/Util.hs
+++ b/haskell/test/Test/Util.hs
@@ -637,6 +637,7 @@ divUp x y = ceiling $ fromIntegral @Integer @Double x / fromIntegral @Integer @D
 infixl 7 `divUp`
 
 -- | @x `isInRange` y $ (down, up)@ checks that @x@ is in the range @[y - down, y + up]@.
+infix 1 `isInRange`
 isInRange
   :: (HasCallStack, MonadNettest caps base m, Ix a, Num a, Buildable a)
   => a -> a -> (a, a) -> m ()
@@ -644,6 +645,7 @@ isInRange x y (marginDown, marginUp) =
   checkCompares (y - marginDown, y + marginUp) inRange x
 
 -- | Similar to `isInRange`, but checks that the lower bound cannot be less than 0.
+infix 1 `isInRangeNat`
 isInRangeNat :: (HasCallStack, MonadNettest caps base m, Coercible nat Natural) => nat -> nat -> (Natural, Natural) -> m ()
 isInRangeNat (coerce -> x) (coerce -> y) (marginDown, marginUp) = do
   let upperBound = y + marginUp

--- a/haskell/test/Test/Util.hs
+++ b/haskell/test/Test/Util.hs
@@ -372,7 +372,7 @@ observe cfmm = do
 -- It should succeed and a position be created if the given address was also
 -- given to 'prepareSomeSegCFMM'.
 setPosition
-  :: (MonadNettest caps base m, HasCallStack)
+  :: (MonadOps m, HasCallStack)
   => ContractHandler Parameter Storage
   -> Natural
   -> (TickIndex, TickIndex)
@@ -390,7 +390,7 @@ setPosition cfmm liquidity (lowerTickIndex, upperTickIndex) = do
       }
 
 updatePosition
-  :: (MonadNettest caps base m, HasCallStack)
+  :: (MonadOps m, HasCallStack)
   => ContractHandler Parameter Storage
   -> Address
   -> Integer
@@ -408,7 +408,7 @@ updatePosition cfmm receiver liquidityDelta positionId = do
       }
 
 xtoy
-  :: (MonadNettest caps base m, HasCallStack)
+  :: (MonadOps m, HasCallStack)
   => ContractHandler Parameter Storage -> Natural -> Address -> m ()
 xtoy cfmm dx receiver =
   call cfmm (Call @"X_to_y") XToYParam
@@ -419,7 +419,7 @@ xtoy cfmm dx receiver =
     }
 
 ytox
-  :: (MonadNettest caps base m, HasCallStack)
+  :: (MonadOps m, HasCallStack)
   => ContractHandler Parameter Storage -> Natural -> Address -> m ()
 ytox cfmm dy receiver =
   call cfmm (Call @"Y_to_x") YToXParam

--- a/haskell/test/Test/XToXPrime.hs
+++ b/haskell/test/Test/XToXPrime.hs
@@ -65,8 +65,9 @@ test_swapping_x_for_x_prime =
       (cfmm2, _) <- prepareSomeSegCFMM accounts (zType, yType) def
         { opTokens = Just (z, y), opModifyConstants = set cFeeBpsL feeBps2 . set cCtezBurnFeeBpsL protoFeeBps2 }
 
-      for_ [cfmm1, cfmm2] \cfmm -> do
-        withSender liquidityProvider $ setPosition cfmm 1_e7 (-1000, 1000)
+      withSender liquidityProvider $ inBatch do
+        for_ [cfmm1, cfmm2] \cfmm -> do
+          setPosition cfmm 1_e7 (-1000, 1000)
 
       initialSt1 <- getStorage cfmm1
       initialSt2 <- getStorage cfmm2

--- a/haskell/test/Test/XToXPrime.hs
+++ b/haskell/test/Test/XToXPrime.hs
@@ -55,9 +55,11 @@ test_swapping_x_for_x_prime =
       transferMoney liquidityProvider 10_e6
       let accounts = [liquidityProvider, swapper]
 
-      x <- originateTokenContract accounts xType (FA2.TokenId 0)
-      y <- originateTokenContract accounts yType (FA2.TokenId 1)
-      z <- originateTokenContract accounts zType (FA2.TokenId 2)
+      (x, y, z) <- originateTokenContracts accounts
+        ( (xType, FA2.TokenId 0)
+        , (yType, FA2.TokenId 1)
+        , (zType, FA2.TokenId 2)
+        )
       (cfmm1, _) <- prepareSomeSegCFMM accounts (xType, yType) def
         { opTokens = Just (x, y), opModifyConstants = set cFeeBpsL feeBps1 . set cCtezBurnFeeBpsL protoFeeBps1 }
       (cfmm2, _) <- prepareSomeSegCFMM accounts (zType, yType) def

--- a/haskell/test/Test/XToXPrime.hs
+++ b/haskell/test/Test/XToXPrime.hs
@@ -17,38 +17,42 @@ import Lorentz hiding (assert, not, now, (>>))
 import qualified Lorentz.Contracts.Spec.FA2Interface as FA2
 import Morley.Nettest
 import Morley.Nettest.Tasty
-import Test.Tasty (TestTree, testGroup)
-import Test.Tasty.Hedgehog (testProperty)
+import Test.Tasty (TestTree)
 
 import SegCFMM.Types
-import Test.Invariants
 import Test.Math
 import Test.SegCFMM.Contract
 import Test.Util
 
 test_swapping_x_for_x_prime :: TestTree
 test_swapping_x_for_x_prime =
-  testGroup "allows swapping X for X'" $
-  ((,,) <$> xTokenTypes <*> yTokenTypes <*> xTokenTypes) <&> \tokenTypes@(xType, yType, zType) ->
-  testProperty (show tokenTypes) $ property do
-    let liquidity = 1_e7
-    let lowerTickIndex = -1000
-    let upperTickIndex = 1000
+  propOnNetwork "allows swapping X for X'"
+    do
+      xType <- forAll $ Gen.element xTokenTypes
+      yType <- forAll $ Gen.element yTokenTypes
+      zType <- forAll $ Gen.element xTokenTypes
 
-    dx <- forAll $ Gen.integral (Range.linear 0 300_000)
-    feeBps1 <- forAll $ Gen.integral (Range.linear 0 10_000)
-    feeBps2 <- forAll $ Gen.integral (Range.linear 0 10_000)
-    protoFeeBps1 <- forAll $ Gen.integral (Range.linear 0 10_000)
-    protoFeeBps2 <- forAll $ Gen.integral (Range.linear 0 10_000)
+      dx <- forAll $ Gen.integral (Range.linear 0 300_000)
+      feeBps1 <- forAll $ Gen.integral (Range.linear 0 10_000)
+      feeBps2 <- forAll $ Gen.integral (Range.linear 0 10_000)
+      protoFeeBps1 <- forAll $ Gen.integral (Range.linear 0 10_000)
+      protoFeeBps2 <- forAll $ Gen.integral (Range.linear 0 10_000)
 
-    -- When the Y token is not CTEZ, we expect the contract to behave as if the protocol fee had been set to zero.
-    let effectiveProtoFeeBps1 = if yType == CTEZ then protoFeeBps1 else 0
-    let effectiveProtoFeeBps2 = if yType == CTEZ then protoFeeBps2 else 0
+      pure ((xType, yType, zType), dx, feeBps1, feeBps2, protoFeeBps1, protoFeeBps2)
+    ( (FA2, CTEZ, FA12)
+    , 20_000
+    , 7_00, 3_00
+    , 3_00, 1_50
+    )
+    \((xType, yType, zType), dx, feeBps1, feeBps2, protoFeeBps1, protoFeeBps2) -> do
+      -- When the Y token is not CTEZ, we expect the contract to behave as if the protocol fee had been set to zero.
+      let effectiveProtoFeeBps1 = if yType == CTEZ then protoFeeBps1 else 0
+      let effectiveProtoFeeBps2 = if yType == CTEZ then protoFeeBps2 else 0
 
-    clevelandProp do
       liquidityProvider <- newAddress auto
       swapper <- newAddress auto
       swapReceiver <- newAddress auto
+      transferMoney liquidityProvider 10_e6
       let accounts = [liquidityProvider, swapper]
 
       x <- originateTokenContract accounts xType (FA2.TokenId 0)
@@ -60,10 +64,10 @@ test_swapping_x_for_x_prime =
         { opTokens = Just (z, y), opModifyConstants = set cFeeBpsL feeBps2 . set cCtezBurnFeeBpsL protoFeeBps2 }
 
       for_ [cfmm1, cfmm2] \cfmm -> do
-        withSender liquidityProvider $ setPosition cfmm liquidity (lowerTickIndex, upperTickIndex)
+        withSender liquidityProvider $ setPosition cfmm 1_e7 (-1000, 1000)
 
-      initialSt1 <- getFullStorage cfmm1
-      initialSt2 <- getFullStorage cfmm2
+      initialSt1 <- getStorage cfmm1
+      initialSt2 <- getStorage cfmm2
       initialBalanceSwapperX <- balanceOf x swapper
       initialBalanceSwapperY <- balanceOf y swapper
       initialBalanceSwapperZ <- balanceOf z swapper
@@ -79,8 +83,6 @@ test_swapping_x_for_x_prime =
           , xppMinDxPrime = 0
           , xppToDxPrime = swapReceiver
           }
-      checkAllInvariants cfmm1
-      checkAllInvariants cfmm2
 
       finalBalanceSwapperX <- balanceOf x swapper
       finalBalanceSwapperY <- balanceOf y swapper
@@ -90,11 +92,11 @@ test_swapping_x_for_x_prime =
       finalBalanceSwapReceiverZ <- balanceOf z swapReceiver
 
       let expectedFee1 = calcSwapFee feeBps1 dx
-      let expectedNewPrice1 = calcNewPriceX (sSqrtPrice initialSt1) (sLiquidity initialSt1) (dx - expectedFee1)
-      let expectedDy = fromIntegral @Integer @Natural $ receivedY (sSqrtPrice initialSt1) (adjustScale @80 expectedNewPrice1) (sLiquidity initialSt1) effectiveProtoFeeBps1
+      let expectedNewPrice1 = calcNewPriceX (sSqrtPriceRPC initialSt1) (sLiquidityRPC initialSt1) (dx - expectedFee1)
+      let expectedDy = fromIntegral @Integer @Natural $ receivedY (sSqrtPriceRPC initialSt1) (adjustScale @80 expectedNewPrice1) (sLiquidityRPC initialSt1) effectiveProtoFeeBps1
       let expectedFee2 = calcSwapFee feeBps2 expectedDy
-      let expectedNewPrice2 = calcNewPriceY (sSqrtPrice initialSt2) (sLiquidity initialSt2) (expectedDy - expectedFee2) effectiveProtoFeeBps2
-      let expectedDz = fromIntegral @Integer @Natural $ receivedX (sSqrtPrice initialSt2) (adjustScale @80 expectedNewPrice2) (sLiquidity initialSt2)
+      let expectedNewPrice2 = calcNewPriceY (sSqrtPriceRPC initialSt2) (sLiquidityRPC initialSt2) (expectedDy - expectedFee2) effectiveProtoFeeBps2
+      let expectedDz = fromIntegral @Integer @Natural $ receivedX (sSqrtPriceRPC initialSt2) (adjustScale @80 expectedNewPrice2) (sLiquidityRPC initialSt2)
 
       finalBalanceSwapperX @== initialBalanceSwapperX - dx
       finalBalanceSwapperY @== initialBalanceSwapperY
@@ -103,7 +105,6 @@ test_swapping_x_for_x_prime =
       finalBalanceSwapReceiverY @== initialBalanceSwapReceiverY
       -- Allow a rounding error of 1 token
       finalBalanceSwapReceiverZ `isInRangeNat` (initialBalanceSwapReceiverZ + expectedDz) $ (1, 1)
-
 
 test_fails_when_y_doesnt_match :: TestTree
 test_fails_when_y_doesnt_match =

--- a/haskell/test/Test/XToY.hs
+++ b/haskell/test/Test/XToY.hs
@@ -60,8 +60,9 @@ test_swapping_within_a_single_tick_range =
       feeReceiver <- newAddress auto
       transferMoney liquidityProvider 10_e6
 
-      (cfmm, (x, y)) <- prepareSomeSegCFMM [liquidityProvider, swapper] tokenTypes def
+      (cfmm, tokens) <- prepareSomeSegCFMM [liquidityProvider, swapper] tokenTypes def
         { opModifyConstants = set cFeeBpsL feeBps . set cCtezBurnFeeBpsL protoFeeBps }
+      balanceConsumers <- originateBalanceConsumers tokens
       -- Add some slots to the buffers to make the tests more meaningful.
       call cfmm (Call @"Increase_observation_count") 10
 
@@ -69,10 +70,9 @@ test_swapping_within_a_single_tick_range =
 
       for_ swaps \dx -> do
         initialSt <- getStorage cfmm
-        initialBalanceSwapperX <- balanceOf x swapper
-        initialBalanceSwapperY <- balanceOf y swapper
-        initialBalanceSwapReceiverX <- balanceOf x swapReceiver
-        initialBalanceSwapReceiverY <- balanceOf y swapReceiver
+        ( (initialBalanceSwapperX, initialBalanceSwapReceiverX),
+          (initialBalanceSwapperY, initialBalanceSwapReceiverY))
+          <- balancesOfMany balanceConsumers (swapper, swapReceiver)
 
         withSender swapper $ xtoy cfmm dx swapReceiver
 
@@ -95,22 +95,27 @@ test_swapping_within_a_single_tick_range =
 
         -- The right amount of tokens was subtracted from the `swapper`'s balance
         let expectedDy = receivedY (sSqrtPriceRPC initialSt) (sSqrtPriceRPC finalSt) (sLiquidityRPC initialSt) effectiveProtoFeeBps
-        balanceOf x swapper @@== initialBalanceSwapperX - dx
-        balanceOf y swapper @@== initialBalanceSwapperY
+
+        ( (finalBalanceSwapperX, finalBalanceSwapReceiverX),
+          (finalBalanceSwapperY, finalBalanceSwapReceiverY))
+          <- balancesOfMany balanceConsumers (swapper, swapReceiver)
+
+        finalBalanceSwapperX @== initialBalanceSwapperX - dx
+        finalBalanceSwapperY @== initialBalanceSwapperY
         -- The right amount of tokens was sent to the `receiver`.
-        balanceOf x swapReceiver @@== initialBalanceSwapReceiverX
-        balanceOf y swapReceiver @@== initialBalanceSwapReceiverY + fromIntegral @Integer @Natural expectedDy
+        finalBalanceSwapReceiverX @== initialBalanceSwapReceiverX
+        finalBalanceSwapReceiverY @== initialBalanceSwapReceiverY + fromIntegral @Integer @Natural expectedDy
 
       -- `feeReceiver` receives the expected fees.
       collectFees cfmm feeReceiver 0 liquidityProvider
-      balanceOf y feeReceiver @@== 0
+      (receivedFeeX, receivedFeeY) <- balancesOf balanceConsumers feeReceiver
       let expectedFees =
             swaps
             <&> (\dx -> calcSwapFee feeBps dx)
             & sum
       -- `update_position` rounds the fee down, so it's possible 1 X token is lost.
-      receivedFee <- balanceOf x feeReceiver
-      receivedFee `isInRangeNat` expectedFees $ (1, 0)
+      receivedFeeX `isInRangeNat` expectedFees $ (1, 0)
+      receivedFeeY @== 0
 
 test_many_small_swaps :: TestTree
 test_many_small_swaps =
@@ -135,10 +140,11 @@ test_many_small_swaps =
     swapper <- newAddress auto
 
     let accounts = [liquidityProvider, swapper]
-    (x, y) <- originateTokenContracts accounts ((fst tokenTypes, FA2.TokenId 0), (snd tokenTypes, FA2.TokenId 1))
-    let origParams = def { opTokens = Just (x, y), opModifyConstants = set cFeeBpsL feeBps . set cCtezBurnFeeBpsL protoFeeBps }
+    tokens <- originateTokenContracts accounts ((fst tokenTypes, FA2.TokenId 0), (snd tokenTypes, FA2.TokenId 1))
+    let origParams = def { opTokens = Just tokens, opModifyConstants = set cFeeBpsL feeBps . set cCtezBurnFeeBpsL protoFeeBps }
     (cfmm1, _) <- prepareSomeSegCFMM accounts tokenTypes origParams
     (cfmm2, _) <- prepareSomeSegCFMM accounts tokenTypes origParams
+    balanceConsumers <- originateBalanceConsumers tokens
 
     for_ [cfmm1, cfmm2] \cfmm -> do
       -- Add some slots to the buffers to make the tests more meaningful.
@@ -172,15 +178,12 @@ test_many_small_swaps =
     -- Due to `dy` being rounded down, it's possible the swapper loses *up to* 1 Y token
     -- on every swap.
     -- So the 2nd contract may hold up to 1000 more Y tokens than the 1st contract.
-    cfmm1YBalance <- balanceOf y cfmm1
-    cfmm2YBalance <- balanceOf y cfmm2
+    (cfmm1XBalance, cfmm1YBalance) <- balancesOf balanceConsumers cfmm1
+    (cfmm2XBalance, cfmm2YBalance) <- balancesOf balanceConsumers cfmm2
     cfmm2YBalance `isInRangeNat` cfmm1YBalance $ (0, swapCount)
 
     -- The two contracts should hold the same exact amount of X tokens
-    cfmm1XBalance <- balanceOf x cfmm1
-    cfmm2XBalance <- balanceOf x cfmm2
     cfmm1XBalance @== cfmm2XBalance
-
 
 test_crossing_ticks :: TestTree
 test_crossing_ticks =
@@ -201,10 +204,11 @@ test_crossing_ticks =
     feeReceiver2 <- newAddress auto
 
     let accounts = [liquidityProvider, swapper]
-    (x, y) <- originateTokenContracts accounts ((fst tokenTypes, FA2.TokenId 0), (snd tokenTypes, FA2.TokenId 1))
-    let origParams = def { opTokens = Just (x, y), opModifyConstants = set cFeeBpsL feeBps }
+    tokens <- originateTokenContracts accounts ((fst tokenTypes, FA2.TokenId 0), (snd tokenTypes, FA2.TokenId 1))
+    let origParams = def { opTokens = Just tokens, opModifyConstants = set cFeeBpsL feeBps }
     (cfmm1, _) <- prepareSomeSegCFMM accounts tokenTypes origParams
     (cfmm2, _) <- prepareSomeSegCFMM accounts tokenTypes origParams
+    balanceConsumers <- originateBalanceConsumers tokens
 
     -- Add some slots to the buffers to make the tests more meaningful.
     for_ [cfmm1, cfmm2] \cfmm -> call cfmm (Call @"Increase_observation_count") 10
@@ -219,10 +223,8 @@ test_crossing_ticks =
     checkAllInvariants cfmm1
     checkAllInvariants cfmm2
 
-    cfmm1InitialBalanceX <- balanceOf x cfmm1
-    cfmm1InitialBalanceY <- balanceOf y cfmm1
-    cfmm2InitialBalanceX <- balanceOf x cfmm2
-    cfmm2InitialBalanceY <- balanceOf y cfmm2
+    (cfmm1InitialBalanceX, cfmm1InitialBalanceY) <- balancesOf balanceConsumers cfmm1
+    (cfmm2InitialBalanceX, cfmm2InitialBalanceY) <- balancesOf balanceConsumers cfmm2
 
     -- Place a small swap to move the tick past 0 and advance the time to fill the
     -- buffer with _something_ other than zeros.
@@ -263,16 +265,17 @@ test_crossing_ticks =
     let marginOfError = pickX (mkX @_ @128 10) `div` liquidity
     feeGrowthX2 `isInRangeNat` feeGrowthX1 $ (0, marginOfError)
 
+    (cfmm1FinalBalanceX, cfmm1FinalBalanceY) <- balancesOf balanceConsumers cfmm1
+    (cfmm2FinalBalanceX, cfmm2FinalBalanceY) <- balancesOf balanceConsumers cfmm2
+    let delta initial final = fromIntegral @Natural @Integer final - fromIntegral @Natural @Integer initial
 
-    let calcBalanceDelta initial final = fromIntegral @Natural @Integer final - fromIntegral @Natural @Integer initial
-    cfmm1BalanceDeltaX <- balanceOf x cfmm1 <&> calcBalanceDelta cfmm1InitialBalanceX
-    cfmm1BalanceDeltaY <- balanceOf y cfmm1 <&> calcBalanceDelta cfmm1InitialBalanceY
-    cfmm2BalanceDeltaX <- balanceOf x cfmm2 <&> calcBalanceDelta cfmm2InitialBalanceX
-    cfmm2BalanceDeltaY <- balanceOf y cfmm2 <&> calcBalanceDelta cfmm2InitialBalanceY
     -- The two contract should have received the exact same amount of X tokens
-    cfmm1BalanceDeltaX @== cfmm2BalanceDeltaX
+    delta cfmm1InitialBalanceX cfmm1FinalBalanceX
+      @== delta cfmm2InitialBalanceX cfmm2FinalBalanceX
     -- The 2nd contract may have given out fewer Y tokens (due to the potential increase in fees)
-    cfmm2BalanceDeltaY `isInRange` cfmm1BalanceDeltaY $ (0, 10)
+    delta cfmm2InitialBalanceY cfmm2FinalBalanceY
+      `isInRange` delta cfmm1InitialBalanceY cfmm1FinalBalanceY $
+      (0, 10)
 
     -- Collected fees should be fairly similar.
     -- As explained above, the contract may charge up to 10 extra tokens.
@@ -280,10 +283,10 @@ test_crossing_ticks =
     -- so we allow for a margin of error of +/-10 X tokens.
     collectAllFees cfmm1 feeReceiver1
     collectAllFees cfmm2 feeReceiver2
-    balanceOf y feeReceiver1 @@== 0
-    balanceOf y feeReceiver2 @@== 0
-    feeReceiver1BalanceX <- balanceOf x feeReceiver1
-    feeReceiver2BalanceX <- balanceOf x feeReceiver2
+    (feeReceiver1BalanceX, feeReceiver1BalanceY) <- balancesOf balanceConsumers feeReceiver1
+    (feeReceiver2BalanceX, feeReceiver2BalanceY) <- balancesOf balanceConsumers feeReceiver2
+    feeReceiver1BalanceY @== 0
+    feeReceiver2BalanceY @== 0
     feeReceiver2BalanceX `isInRangeNat` feeReceiver1BalanceX $ (10, 10)
 
     -- The global accumulators of both contracts should be the same.
@@ -307,7 +310,8 @@ test_fee_split =
     swapper <- newAddress auto
     feeReceiver1 <- newAddress auto
     feeReceiver2 <- newAddress auto
-    (cfmm, (x, y)) <- prepareSomeSegCFMM [liquidityProvider, swapper] tokenTypes def { opModifyConstants = set cFeeBpsL feeBps }
+    (cfmm, tokens) <- prepareSomeSegCFMM [liquidityProvider, swapper] tokenTypes def { opModifyConstants = set cFeeBpsL feeBps }
+    (x, y) <- originateBalanceConsumers tokens
 
     withSender liquidityProvider do
       setPosition cfmm 1_e6 (-100, 100)
@@ -380,7 +384,8 @@ test_swaps_are_noops_when_liquidity_is_zero =
   nettestScenarioOnEmulatorCaps (show tokenTypes) do
     liquidityProvider <- newAddress auto
     swapper <- newAddress auto
-    (cfmm, (x, y)) <- prepareSomeSegCFMM [liquidityProvider, swapper] tokenTypes def
+    (cfmm, tokens) <- prepareSomeSegCFMM [liquidityProvider, swapper] tokenTypes def
+    balanceConsumers <- originateBalanceConsumers tokens
     withSender liquidityProvider $ setPosition cfmm 10_000 (-100, 100)
 
     withSender swapper do
@@ -390,12 +395,10 @@ test_swaps_are_noops_when_liquidity_is_zero =
       let
         isNoOp op = do
           initialSt <- getFullStorage cfmm
-          initialBalanceX <- balanceOf x cfmm
-          initialBalanceY <- balanceOf y cfmm
+          initialBalance <- balancesOf balanceConsumers cfmm
           op
           getFullStorage cfmm @@== initialSt
-          balanceOf x cfmm @@== initialBalanceX
-          balanceOf y cfmm @@== initialBalanceY
+          balancesOf balanceConsumers cfmm @@== initialBalance
 
       isNoOp $ xtoy cfmm 100 swapper
       isNoOp $ ytox cfmm 100 swapper
@@ -445,8 +448,9 @@ test_protocol_fees_are_burned =
     liquidityProvider <- newAddress auto
     swapper <- newAddress auto
     let accounts = [liquidityProvider, swapper]
-    (cfmm, (_, y)) <- prepareSomeSegCFMM accounts (xTokenType, CTEZ) def
+    (cfmm, tokens) <- prepareSomeSegCFMM accounts (xTokenType, CTEZ) def
       { opModifyConstants = set cFeeBpsL feeBps . set cCtezBurnFeeBpsL protoFeeBps }
+    y <- originateBalanceConsumer (snd tokens)
 
     withSender liquidityProvider $ setPosition cfmm 10_000 (-100, 100)
 

--- a/haskell/test/Test/XToY.hs
+++ b/haskell/test/Test/XToY.hs
@@ -135,8 +135,7 @@ test_many_small_swaps =
     swapper <- newAddress auto
 
     let accounts = [liquidityProvider, swapper]
-    x <- originateTokenContract accounts (fst tokenTypes) (FA2.TokenId 0)
-    y <- originateTokenContract accounts (snd tokenTypes) (FA2.TokenId 1)
+    (x, y) <- originateTokenContracts accounts ((fst tokenTypes, FA2.TokenId 0), (snd tokenTypes, FA2.TokenId 1))
     let origParams = def { opTokens = Just (x, y), opModifyConstants = set cFeeBpsL feeBps . set cCtezBurnFeeBpsL protoFeeBps }
     (cfmm1, _) <- prepareSomeSegCFMM accounts tokenTypes origParams
     (cfmm2, _) <- prepareSomeSegCFMM accounts tokenTypes origParams
@@ -202,8 +201,7 @@ test_crossing_ticks =
     feeReceiver2 <- newAddress auto
 
     let accounts = [liquidityProvider, swapper]
-    x <- originateTokenContract accounts (fst tokenTypes) (FA2.TokenId 0)
-    y <- originateTokenContract accounts (snd tokenTypes) (FA2.TokenId 1)
+    (x, y) <- originateTokenContracts accounts ((fst tokenTypes, FA2.TokenId 0), (snd tokenTypes, FA2.TokenId 1))
     let origParams = def { opTokens = Just (x, y), opModifyConstants = set cFeeBpsL feeBps }
     (cfmm1, _) <- prepareSomeSegCFMM accounts tokenTypes origParams
     (cfmm2, _) <- prepareSomeSegCFMM accounts tokenTypes origParams

--- a/haskell/test/Test/XToY.hs
+++ b/haskell/test/Test/XToY.hs
@@ -16,42 +16,49 @@ import qualified Lorentz.Contracts.Spec.FA2Interface as FA2
 import Morley.Nettest
 import Morley.Nettest.Tasty
 import Test.Tasty (TestTree, testGroup)
-import Test.Tasty.Hedgehog (testProperty)
 import Tezos.Core (timestampPlusSeconds)
 
 import SegCFMM.Errors
 import SegCFMM.Types
 import Test.Invariants
 import Test.Math
-import Test.SegCFMM.Contract (TokenType(..), xTokenTypes)
+import Test.SegCFMM.Contract
 import Test.Util
 import Util.Named
 
 test_swapping_within_a_single_tick_range :: TestTree
 test_swapping_within_a_single_tick_range =
-  forAllTokenTypeCombinations "swapping within a single tick range" \tokenTypes ->
-  testProperty (show tokenTypes) $ property do
-    let liquidity = 1_e7
-    let lowerTickIndex = -1000
-    let upperTickIndex = 1000
+  propOnNetwork "swapping within a single tick range"
+    do
+      tokenTypes <- forAll $ Gen.element allTokenTypeCombinations
+      feeBps <- forAll $ Gen.integral (Range.linear 0 100_00)
+      protoFeeBps <- forAll $ Gen.integral (Range.linear 0 100_00)
 
-    -- With the liquidity above, we can deposit a little more than 500_000 Y tokens.
-    -- So we'll generate up to 10 swaps of 50_000 tokens each.
-    swaps <- forAll $
-      Gen.list (Range.linear 1 10) $
-        Gen.integral (Range.linear 0 50_000)
+      -- With 1_e7 liquidity, we can deposit a little more than 500_000 Y tokens.
+      -- So we'll generate up to 10 swaps of 50_000 tokens each.
+      swaps <- forAll $
+        Gen.list (Range.linear 1 10) $
+          Gen.integral (Range.linear 0 50_000)
 
-    feeBps <- forAll $ Gen.integral (Range.linear 0 100_00)
-    protoFeeBps <- forAll $ Gen.integral (Range.linear 0 100_00)
+      pure (tokenTypes, feeBps, protoFeeBps, swaps)
+    ( defaultTokenTypes
+    , 7_00
+    , 7_00
+    , [1, 10, 100, 10_000]
+    )
+    \(tokenTypes, feeBps, protoFeeBps, swaps) -> do
+      let liquidity = 1_e7
+      let lowerTickIndex = -1000
+      let upperTickIndex = 1000
 
-    -- When the Y token is not CTEZ, we expect the contract to behave as if the protocol fee had been set to zero.
-    let effectiveProtoFeeBps = if snd tokenTypes == CTEZ then protoFeeBps else 0
+      -- When the Y token is not CTEZ, we expect the contract to behave as if the protocol fee had been set to zero.
+      let effectiveProtoFeeBps = if snd tokenTypes == CTEZ then protoFeeBps else 0
 
-    clevelandProp do
       liquidityProvider <- newAddress auto
       swapper <- newAddress auto
       swapReceiver <- newAddress auto
       feeReceiver <- newAddress auto
+      transferMoney liquidityProvider 10_e6
 
       (cfmm, (x, y)) <- prepareSomeSegCFMM [liquidityProvider, swapper] tokenTypes def
         { opModifyConstants = set cFeeBpsL feeBps . set cCtezBurnFeeBpsL protoFeeBps }
@@ -61,7 +68,7 @@ test_swapping_within_a_single_tick_range =
       withSender liquidityProvider $ setPosition cfmm liquidity (lowerTickIndex, upperTickIndex)
 
       for_ swaps \dx -> do
-        initialSt <- getFullStorage cfmm
+        initialSt <- getStorage cfmm
         initialBalanceSwapperX <- balanceOf x swapper
         initialBalanceSwapperY <- balanceOf y swapper
         initialBalanceSwapReceiverX <- balanceOf x swapReceiver
@@ -71,24 +78,23 @@ test_swapping_within_a_single_tick_range =
 
         -- Advance the time 1 sec to make sure the buffer is updated to reflect the swaps.
         advanceSecs 1 [cfmm]
-        checkAllInvariants cfmm
 
-        finalSt <- getFullStorage cfmm
+        finalSt <- getStorage cfmm
 
         -- The contract's `sqrt_price` has moved accordingly.
         let expectedFee = calcSwapFee feeBps dx
-        let expectedNewPrice = calcNewPriceX (sSqrtPrice initialSt) (sLiquidity initialSt) (dx - expectedFee)
-        adjustScale @30 (sSqrtPrice finalSt) @== expectedNewPrice
+        let expectedNewPrice = calcNewPriceX (sSqrtPriceRPC initialSt) (sLiquidityRPC initialSt) (dx - expectedFee)
+        adjustScale @30 (sSqrtPriceRPC finalSt) @== expectedNewPrice
         when (dx > 0 && feeBps > 0) do checkCompares expectedFee (>=) 1
 
         -- Check fee growth
         let expectedFeeGrowth =
-              sFeeGrowth initialSt +
+              sFeeGrowthRPC initialSt +
                 PerToken (mkX @Natural @128 expectedFee `div` X liquidity) 0
-        sFeeGrowth finalSt @== expectedFeeGrowth
+        sFeeGrowthRPC finalSt @== expectedFeeGrowth
 
         -- The right amount of tokens was subtracted from the `swapper`'s balance
-        let expectedDy = receivedY (sSqrtPrice initialSt) (sSqrtPrice finalSt) (sLiquidity initialSt) effectiveProtoFeeBps
+        let expectedDy = receivedY (sSqrtPriceRPC initialSt) (sSqrtPriceRPC finalSt) (sLiquidityRPC initialSt) effectiveProtoFeeBps
         balanceOf x swapper @@== initialBalanceSwapperX - dx
         balanceOf y swapper @@== initialBalanceSwapperY
         -- The right amount of tokens was sent to the `receiver`.
@@ -96,7 +102,7 @@ test_swapping_within_a_single_tick_range =
         balanceOf y swapReceiver @@== initialBalanceSwapReceiverY + fromIntegral @Integer @Natural expectedDy
 
       -- `feeReceiver` receives the expected fees.
-      collectAllFees cfmm feeReceiver
+      collectFees cfmm feeReceiver 0 liquidityProvider
       balanceOf y feeReceiver @@== 0
       let expectedFees =
             swaps

--- a/haskell/test/Test/YToX.hs
+++ b/haskell/test/Test/YToX.hs
@@ -135,8 +135,7 @@ test_many_small_swaps =
     swapper <- newAddress auto
 
     let accounts = [liquidityProvider, swapper]
-    x <- originateTokenContract accounts (fst tokenTypes) (FA2.TokenId 0)
-    y <- originateTokenContract accounts (snd tokenTypes) (FA2.TokenId 1)
+    (x, y) <- originateTokenContracts accounts ((fst tokenTypes, FA2.TokenId 0), (snd tokenTypes, FA2.TokenId 1))
     let origParams = def { opTokens = Just (x, y), opModifyConstants = set cFeeBpsL feeBps . set cCtezBurnFeeBpsL protoFeeBps }
     (cfmm1, _) <- prepareSomeSegCFMM accounts tokenTypes origParams
     (cfmm2, _) <- prepareSomeSegCFMM accounts tokenTypes origParams
@@ -200,8 +199,7 @@ test_crossing_ticks =
     feeReceiver2 <- newAddress auto
 
     let accounts = [liquidityProvider, swapper]
-    x <- originateTokenContract accounts (fst tokenTypes) (FA2.TokenId 0)
-    y <- originateTokenContract accounts (snd tokenTypes) (FA2.TokenId 1)
+    (x, y) <- originateTokenContracts accounts ((fst tokenTypes, FA2.TokenId 0), (snd tokenTypes, FA2.TokenId 1))
     let origParams = def { opTokens = Just (x, y), opModifyConstants = set cFeeBpsL feeBps }
     (cfmm1, _) <- prepareSomeSegCFMM accounts tokenTypes origParams
     (cfmm2, _) <- prepareSomeSegCFMM accounts tokenTypes origParams

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "2051e81503e4b10f82f877ef06abc5c6f89576f7",
-        "sha256": "1zkg1cilwsai6brvmh1zh9ih7f8sbl4am94xb37fb6zsh1pzychs",
+        "rev": "5786405063958e417fdbcf7e75686f35d63708ac",
+        "sha256": "0r8aml05skzidmg8ma0gfmb72fqv3vm1xajnrkshqc8ygwhp3bwd",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/hackage.nix/archive/2051e81503e4b10f82f877ef06abc5c6f89576f7.tar.gz",
+        "url": "https://github.com/input-output-hk/hackage.nix/archive/5786405063958e417fdbcf7e75686f35d63708ac.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "haskell-nix-weeder": {
@@ -85,15 +85,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "tezos-packaging": {
-        "branch": "v9.2-1",
+        "branch": "master",
         "description": "Various form of distribution for tezos-related executables",
         "homepage": "",
         "owner": "serokell",
         "repo": "tezos-packaging",
-        "rev": "4ff58e4163ef2fca6baf8a12aad16b5c84443037",
-        "sha256": "084smlxxyczja6px38sx3zbxx0p0n1bmjwsg6k1ssnv9q6nm2qjm",
+        "rev": "2fd958106fc9cd318b68c3a8eef5091bcb0877ba",
+        "sha256": "0j5jb5vyvfjzwcb0giz8as3aafd2gn1n78is92s3yjz05zqdgjsg",
         "type": "tarball",
-        "url": "https://github.com/serokell/tezos-packaging/archive/4ff58e4163ef2fca6baf8a12aad16b5c84443037.tar.gz",
+        "url": "https://github.com/serokell/tezos-packaging/archive/2fd958106fc9cd318b68c3a8eef5091bcb0877ba.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "xrefcheck": {


### PR DESCRIPTION
[//]: # (This is a template of a pull request template.)
[//]: # (You should modify it considering specifics of a particular repository and put it there.)
[//]: # (Comments like this are meta-comments, they shouldn't be present in the final template.)
[//]: # (Comments starting with '<!---' are intended to stay in the final template.)

[//]: # (Keep in mind that it's only a template which contains items relevant to almost all conceivable repository.)
[//]: # (There can be other important items relevant to your repository that you can add here.)

## Description

This PR enables network tests. It also improves the execution time of said tests by performing as many operations as possible in batches.

With the batching optimizations, the tests seem to be taking ~15 mins on a local chain, which is IMO acceptable.

As previously discussed, running all tests on a network would be extremely costly, so I went with this approach:
* Select a couple of meaningful tests from each test suite
* Tests that check all FA1.2/FA2/CTEZ variants: they test only the FA2-CTEZ variant when running on a network (see `Test.Util.forAllTokenTypeCombinationsOnNetwork`)
* Property tests: they're converted to example-based tests when running on a network (see `Test.Util.propOnNetwork`)

Regarding the selected tests:
* Tests from `RangeOracles`, `TimedOracle` and `Mining` are extremely time-sensitive, they would fail on a network. Technically, we _could_ write additional tests, similar to the existing ones, but with less strict checks. I'm not sure this is worth the effort though.
* The tests from the `Test.FA2` and `Test.FA2.BalanceOf` suites already cover all FA2 entrypoints, so I didn't see the need to select any tests from the `Transfer` and `UpdateOperator` suites.

Here's a successful pipeline run for local-chain 010, 011, granadanet and hangzhounet: https://buildkite.com/serokell/segmented-cfmm/builds/652

[//]: # (Here you can add a link to the corresponding issue tracker, e. g. https://issues.serokell.io/issue/AD-)
[//]: # (For GitHub/GitLab issues it is better to use just hash symbol or exclamation mark as it is more resistant to repo movements)
[//]: # (In this case please also prefix the link with "Resolves" keyword)
[//]: # (See https://docs.gitlab.com/ee/user/project/issues/managing_issues.html#closing-issues-automatically)
[//]: # (See https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords)
## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves TCFMM-42

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [Specification](../tree/master/docs/specification.md)
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

[//]: # (Update link to style guide if necesary or remove if it's not present)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
