### PR TITLE
[TCFMM-29] Cut size and execution costs

### DIFF
--- a/docs/compilation.md
+++ b/docs/compilation.md
@@ -11,7 +11,7 @@ in particular its CameLIGO dialect.
 To compile to Michelson the contract code and/or its storage, you'll need to have
 the [ligo executable](https://ligolang.org/docs/intro/installation) installed.
 
-The latest working version tested is [0.16.1](https://gitlab.com/ligolang/ligo/-/releases/0.16.1).
+The latest working version tested is [0.30.0](https://gitlab.com/ligolang/ligo/-/releases/0.30.0).
 
 ## Compiling the contract
 

--- a/haskell/package.yaml
+++ b/haskell/package.yaml
@@ -6,7 +6,7 @@ version:             0.0.1.0
 license:             MIT
 license-file:        LICENSE
 author:              Serokell, Arthur Breitman
-git:                 git@github.com:serokell/segmented-cfmm.git
+git:                 git@github.com:tezos-checker/segmented-cfmm.git
 copyright:           2021 Arthur Breitman
 
 extra-doc-files:

--- a/haskell/segmented-cfmm.cabal
+++ b/haskell/segmented-cfmm.cabal
@@ -18,7 +18,7 @@ extra-doc-files:
 
 source-repository head
   type: git
-  location: git@github.com:serokell/segmented-cfmm.git
+  location: git@github.com:tezos-checker/segmented-cfmm.git
 
 library
   exposed-modules:

--- a/haskell/src/SegCFMM/TZIP16Metadata.hs
+++ b/haskell/src/SegCFMM/TZIP16Metadata.hs
@@ -79,7 +79,7 @@ mkSegCfmmMetadata settings =
       , version . fromString $ showVersion Paths.version
       , license $ License "MIT" Nothing
       , authors [Author "Serokell", Author "Arthur Breitman"]
-      , homepage "https://github.com/serokell/segmented-cfmm"
+      , homepage "https://github.com/tezos-checker/segmented-cfmm"
       , interfaces [tzip 16]
       , views (segCfmmViews settings)
       ]

--- a/ligo/defaults.mligo
+++ b/ligo/defaults.mligo
@@ -132,8 +132,8 @@ let default_storage
 
 (* Identity contract using 'parameter' and 'storage'.
  *
- * This is only used for the purpose of providing an `ENTRY_POINT` to the
- * `compile-storage` command of LIGO.
+ * This is only used for the purpose of providing an `--entry-point` to the
+ * `compile storage` command of LIGO.
 *)
 let entrypoint (_param, store : parameter * storage) : result =
   (([] : operation list), store)

--- a/ligo/helpers.mligo
+++ b/ligo/helpers.mligo
@@ -35,6 +35,7 @@
               "sqrt_price_move_x 100n {x80 = 12089258196146291747061760n} 10n"
             6044629098073145873530880
    *)
+[@inline]
 let sqrt_price_move_x (liquidity : nat) (sqrt_price_old : x80n) (dx : nat) : x80n =
     (* floordiv because we want to overstate how much this trade lowers the price *)
     let sqrt_price_new =

--- a/ligo/helpers.mligo
+++ b/ligo/helpers.mligo
@@ -92,12 +92,14 @@ let sqrt_price_move_y (liquidity : nat) (sqrt_price_old : x80n) (dy : nat) : x80
     sqrt_price_new
 
 (* Helper function to grab a tick we know exists in the tick indexed state. *)
+[@inline]
 let get_tick (ticks : (tick_index, tick_state) big_map) (index: tick_index) (error_code: nat) : tick_state =
     match Big_map.find_opt index ticks with
     | None -> failwith error_code
     | Some state -> state
 
 (* Check if a request has expired. *)
+[@inline]
 let check_deadline (deadline : timestamp) : unit =
     if Tezos.now > deadline
         then ([%Michelson ({| { FAILWITH } |} : nat * (timestamp * timestamp) -> unit)]
@@ -107,8 +109,8 @@ let check_deadline (deadline : timestamp) : unit =
 [@inline]
 let get_registered_cumulatives_unsafe (buffer : timed_cumulatives_buffer) (i : nat) : timed_cumulatives =
     match Big_map.find_opt i buffer.map with
-        | None -> failwith internal_bad_access_to_observation_buffer
-        | Some v -> v
+    | None -> failwith internal_bad_access_to_observation_buffer
+    | Some v -> v
 
 [@inline]
 let get_last_cumulatives (buffer : timed_cumulatives_buffer) : timed_cumulatives =
@@ -117,8 +119,8 @@ let get_last_cumulatives (buffer : timed_cumulatives_buffer) : timed_cumulatives
 
 (* Ensure tick index is multiple of tick spacing. *)
 [@inline]
-let check_multiple_of_tick_spacing (tick_index, storage: tick_index * storage) : unit =
-    if (tick_index.i mod storage.constants.tick_spacing = 0n)
+let check_multiple_of_tick_spacing (tick_index, tick_spacing: tick_index * nat) : unit =
+    if (tick_index.i mod tick_spacing = 0n)
         then unit
         else failwith incorrect_tick_spacing_err
 

--- a/ligo/main.mligo
+++ b/ligo/main.mligo
@@ -9,16 +9,6 @@
 #include "swaps.mligo"
 #include "token/fa2.mligo"
 
-[@inline]
-let get_registered_cumulatives_unsafe (buffer : timed_cumulatives_buffer) (i : nat) : timed_cumulatives =
-    match Big_map.find_opt i buffer.map with
-        | None -> failwith internal_bad_access_to_observation_buffer
-        | Some v -> v
-
-[@inline]
-let get_last_cumulatives (buffer : timed_cumulatives_buffer) : timed_cumulatives =
-    get_registered_cumulatives_unsafe buffer buffer.last
-
 let rec initialize_tick ((ticks, tick_index, tick_witness,
     initial_tick_cumulative_outside,
     initial_fee_growth_outside,
@@ -226,8 +216,9 @@ let update_cur_tick_witness (s : storage) (tick_index : tick_index) : storage =
 
 let set_position (s : storage) (p : set_position_param) : result =
     let _: unit = check_deadline p.deadline in
-    let _: unit = check_multiple_of_tick_spacing (p.lower_tick_index, s) in
-    let _: unit = check_multiple_of_tick_spacing (p.upper_tick_index, s) in
+    let allowed_tick_spacing = s.constants.tick_spacing in
+    let _: unit = check_multiple_of_tick_spacing (p.lower_tick_index, allowed_tick_spacing) in
+    let _: unit = check_multiple_of_tick_spacing (p.upper_tick_index, allowed_tick_spacing) in
     let _: unit = if p.lower_tick_index >= p.upper_tick_index then failwith tick_order_err else unit in
 
     // Creating position with 0 liquidity must result in no changes being made

--- a/ligo/main.mligo
+++ b/ligo/main.mligo
@@ -311,7 +311,7 @@ let update_position (s : storage) (p : update_position_param) : result =
     let _: unit = check_deadline p.deadline in
 
     (* Grab the existing position *)
-    let position = get_position (p.position_id, s) in
+    let position = get_position (p.position_id, s.positions) in
     (* Get accumulated fees for this position. *)
     let s, fees, position = collect_fees s p.position_id position in
 
@@ -551,7 +551,7 @@ let update_timed_cumulatives (s : storage) : storage =
         in {s with cumulatives_buffer = new_buffer}
 
 let get_position_info (s : storage) (p : get_position_info_param) : result =
-    let position = get_position(p.position_id, s) in
+    let position = get_position(p.position_id, s.positions) in
     let result =
         { liquidity = position.liquidity
         ; owner = position.owner

--- a/ligo/math.mligo
+++ b/ligo/math.mligo
@@ -20,17 +20,20 @@ let floordiv (numerator : nat) (denominator : nat) : nat =  numerator / denomina
     2 * ln(x/y) / ln(1.0001)
  *)
 (* accurate for x/y in [0.7, 1.5] *)
-(* Note, for simplify, our sqrt_prices are not on a grid of 0.5 bps, they are on a grid of 10000 (Exp[0.0005] - 1) bps *)
+(* Note, for simplicity, our sqrt_prices are not on a grid of 0.5 bps, they are on a grid of 10000 (Exp[0.0005] - 1) bps *)
+[@inline]
 let floor_log_half_bps ((x, y, out_of_bounds_err) : nat * nat * nat) : int =
     let tenx = 10n * x in
-    if tenx < 7n * y or tenx > 15n * y then
-        (failwith out_of_bounds_err : int)
-    else
-        let x_plus_y = x + y in
-        let num : int = 60003 * (x - y) * (int x_plus_y) in
-        let denom = x_plus_y * x_plus_y + 2n * x * y in
-        num / (int denom)
+    let _ : unit =
+            if tenx < 7n * y or tenx > 15n * y then failwith out_of_bounds_err
+            else unit
+    in
+    let x_plus_y = x + y in
+    let num : int = 60003 * (x - y) * x_plus_y in
+    let denom = x_plus_y * x_plus_y + 2n * x * y in
+    num / denom
 
+[@inline]
 let floor_log_half_bps_x80 ((x, y, out_of_bounds_err) : x80n * x80n * nat) : int =
     match (x, y) with
         ({x80 = x0}, {x80 = y0}) -> floor_log_half_bps(x0, y0, out_of_bounds_err)
@@ -44,40 +47,41 @@ let assert_nat (x, error_code : int * nat) : nat =
     This function handles larger values of `y`.
  *)
 let rec stepped_shift_right (x, y : nat * nat) : nat =
-    if y <= 256n then
+    let max_shift = 256n in
+    if y <= max_shift then
         Bitwise.shift_right x y
     else
-        let new_x = Bitwise.shift_right x 256n in
-        stepped_shift_right (new_x, abs (y - 256))
+        let new_x = Bitwise.shift_right x max_shift in
+        stepped_shift_right (new_x, abs (y - max_shift))
 
 (* `Bitwise.shift_left x y` is only defined for `y <= 256n`.
     This function handles larger values of `y`.
  *)
 let rec stepped_shift_left (x, y : nat * nat) : nat =
-    if y <= 256n then
+    let max_shift = 256n in
+    if y <= max_shift then
         Bitwise.shift_left x y
     else
-        let new_x = Bitwise.shift_left x 256n in
-        stepped_shift_left (new_x, abs (y - 256))
-
-
-let unsafe_ediv (x, y : nat * nat) : (nat * nat) =
-    match ediv x y with
-    | None -> (failwith internal_impossible_err : nat * nat)
-    | Some d -> d
-
+        let new_x = Bitwise.shift_left x max_shift in
+        stepped_shift_left (new_x, abs (y - max_shift))
 
 let rec half_bps_pow_rec ((tick, acc, ladder_key, ladder) : nat * fixed_point * ladder_key * ladder) : fixed_point =
     if tick = 0n then
         acc
     else
-        let (half, rem) = unsafe_ediv (tick, 2n) in
-        match Big_map.find_opt ladder_key ladder with
-        | None -> (failwith price_out_of_bounds_err : fixed_point)
-        | Some h ->
-            let new_acc = if rem = 0n then acc else fixed_point_mul h acc in
-            let new_ladder_key = {ladder_key with exp = ladder_key.exp + 1n} in
-            half_bps_pow_rec (half, new_acc, new_ladder_key, ladder)
+        let (half, rem) =
+                match ediv tick 2n with
+                | None -> (failwith internal_impossible_err : nat * nat)
+                | Some d -> d
+        in
+        let fixed_point =
+                match Big_map.find_opt ladder_key ladder with
+                | None -> (failwith price_out_of_bounds_err : fixed_point)
+                | Some h -> h
+        in
+        let new_acc = if rem = 0n then acc else fixed_point_mul fixed_point acc in
+        let new_ladder_key = {ladder_key with exp = ladder_key.exp + 1n} in
+        half_bps_pow_rec (half, new_acc, new_ladder_key, ladder)
 
 (*
   For a tick index `i`, calculate the corresponding `sqrt_price`:

--- a/ligo/token/fa2.mligo
+++ b/ligo/token/fa2.mligo
@@ -8,30 +8,29 @@
 // -----------------------------------------------------------------
 
 [@inline]
-let get_position (position_id, store : position_id * storage) : position_state =
-  match (Big_map.find_opt position_id store.positions) with
-    | Some position -> position
-    | None -> ([%Michelson ({| { FAILWITH } |} : string * unit -> position_state)]
-          ("FA2_TOKEN_UNDEFINED", ()) : position_state)
+let get_position (position_id, positions : position_id * position_map) : position_state =
+  match Big_map.find_opt position_id positions with
+  | Some position -> position
+  | None -> ([%Michelson ({| { FAILWITH } |} : string * unit -> position_state)]
+        ("FA2_TOKEN_UNDEFINED", ()) : position_state)
 
 [@inline]
-let check_sender (from_ , token_id, store : address * token_id * storage): address =
-  if (Tezos.sender = from_) then from_
+let check_sender (from_ , token_id, operators : address * token_id * operators): unit =
+  if (Tezos.sender = from_) then unit
   else
     let key: operator_param = { owner = from_; operator = Tezos.sender; token_id = token_id } in
-    if Big_map.mem key store.operators then
-      from_
+    if Big_map.mem key operators then unit
     else
-     ([%Michelson ({| { FAILWITH } |} : string * unit -> address)]
-        ("FA2_NOT_OPERATOR", ()) : address)
+     ([%Michelson ({| { FAILWITH } |} : string * unit -> unit)]
+        ("FA2_NOT_OPERATOR", ()) : unit)
 
 (* A function that combines the usual FA2's `debit_from` and `credit_to`. *)
 [@inline]
-let change_position_owner (from_, tx, store: address * transfer_destination * storage): storage =
+let change_position_owner (from_, tx, positions: address * transfer_destination * position_map): position_map =
   if tx.amount = 0n then
-    store // We allow 0 transfer
+    positions // We allow 0 transfer
   else
-    let position = get_position(tx.token_id, store) in
+    let position = get_position(tx.token_id, positions) in
 
     // Ensure `from_` is the owner of the position.
     let owned_amount = if position.owner = from_ then 1n else 0n in
@@ -42,8 +41,7 @@ let change_position_owner (from_, tx, store: address * transfer_destination * st
             ("FA2_INSUFFICIENT_BALANCE", (tx.amount, owned_amount))) in
 
     let new_position = { position with owner = tx.to_ } in
-    let positions = Big_map.add tx.token_id new_position store.positions in
-    { store with positions = positions }
+    Big_map.add tx.token_id new_position positions
 
 
 // -----------------------------------------------------------------
@@ -52,8 +50,9 @@ let change_position_owner (from_, tx, store: address * transfer_destination * st
 
 let transfer_item (store, ti : storage * transfer_item): storage =
   let transfer_one (store, tx : storage * transfer_destination): storage =
-    let valid_from = check_sender (ti.from_, tx.token_id, store) in
-    change_position_owner (valid_from, tx, store)
+    let _ : unit = check_sender (ti.from_, tx.token_id, store.operators) in
+    let new_positions = change_position_owner (ti.from_, tx, store.positions) in
+    { store with positions = new_positions }
   in List.fold transfer_one ti.txs store
 
 let transfer (params, store : transfer_params * storage): result =
@@ -66,8 +65,9 @@ let transfer (params, store : transfer_params * storage): result =
 // -----------------------------------------------------------------
 
 let balance_of (params, store : balance_request_params * storage): result =
+  let positions = store.positions in
   let check_one (req : balance_request_item): balance_response_item =
-    let pos_index = get_position(req.token_id, store) in
+    let pos_index = get_position(req.token_id, positions) in
     let bal = if req.owner = pos_index.owner then 1n else 0n in
     { request = req; balance = bal } in
   let result = List.map check_one params.requests in
@@ -78,23 +78,20 @@ let balance_of (params, store : balance_request_params * storage): result =
 // Update operators entrypoint
 // -----------------------------------------------------------------
 
-let update_one (store, param: storage * update_operator): storage =
+let update_one (operators, param: operators * update_operator): operators =
   let (operator_update, operator_param) =
     match param with
     | Add_operator p -> (Some unit, p)
     | Remove_operator p -> ((None : unit option), p) in
-  if (Tezos.sender = operator_param.owner) then
-    let updated_operators = Big_map.update operator_param operator_update store.operators
-    in  { store with
-          operators = updated_operators
-        }
-  else
-     ([%Michelson ({| { FAILWITH } |} : string * unit -> storage)]
-        ("FA2_NOT_OWNER", ()) : storage)
+  let _ : unit =
+    if (Tezos.sender = operator_param.owner) then unit
+    else ([%Michelson ({| { FAILWITH } |} : string * unit -> unit)]
+          ("FA2_NOT_OWNER", ()) : unit)
+  in Big_map.update operator_param operator_update operators
 
 let update_operators (params, store : update_operators_param * storage):result =
-  let store = List.fold update_one params store in
-  (([] : operation list), store)
+  let updated_operators = List.fold update_one params store.operators in
+  (([] : operation list), { store with operators = updated_operators })
 
 
 let call_fa2 (store : storage) (param : fa2_parameter) : result =

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -36,10 +36,10 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "ligo": {
-        "sha256": "8f12f5f4e3e0630c3305befc6e8d304144b86debf4df845e6b9778876825b697",
+        "sha256": "8aba789f479735769a0e41b5be37264073266a86f5c91f24a9d9f1d8f43a098e",
         "type": "file",
-        "url": "https://gitlab.com/ligolang/ligo/-/jobs/1266799625/artifacts/raw/ligo",
-        "url_template": "https://gitlab.com/ligolang/ligo/-/jobs/1266799625/artifacts/raw/ligo"
+        "url": "https://gitlab.com/ligolang/ligo/-/jobs/1816125591/artifacts/raw/ligo",
+        "url_template": "https://gitlab.com/ligolang/ligo/-/jobs/1816125591/artifacts/raw/ligo"
     },
     "morley": {
         "sha256": "0g9mdqb7l85z8qa931lxmcqrzhscq6451plz1k18v738ylx4dxmj",


### PR DESCRIPTION
## Description

This PR attempts at reducing the contract size and entrypoint gas execution costs, without changing the contract logic.
_Note: when it was clear I preferred gas cost over contract size and when in doubt I avoided changes._

The contract size reduction after these changes is of about `1200` bytes on the default options (with debug enabled).

Additionally this bumps the ligo version used as well.

## Related issue(s)

Resolves TCFMM-29

## :white_check_mark: Checklist for your Pull Request

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [Specification](../tree/master/docs/specification.md)
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

[//]: # (Update link to style guide if necesary or remove if it's not present)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
