### PR TITLE
[Chore] Remove tests from CI for protocol 010

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -66,15 +66,6 @@ steps:
       - nix-build ci.nix -A packages.segmented-cfmm.tests.segmented-cfmm-test
       - ./result/bin/segmented-cfmm-test --nettest-mode=disable-network
 
-  - label: ligo-test-local-chain-010
-    if: *not-scheduled
-    <<: *network-tests
-    env:
-      # this key is defined in local-chain bootstrap accounts list in
-      # https://github.com/serokell/aquarius-infra/blob/master/servers/albali/chain.nix
-      TASTY_NETTEST_IMPORT_SECRET_KEY: "unencrypted:edsk42cYfuawC5i3PmuS3Lq73pAzgrJyVNcv9CXQspM2dG4M9QMpeS"
-      TASTY_NETTEST_NODE_ENDPOINT: "http://localhost:8733"
-
   - label: ligo-test-local-chain-011
     if: *not-scheduled
     <<: *network-tests
@@ -83,15 +74,6 @@ steps:
       # https://github.com/serokell/aquarius-infra/blob/master/servers/albali/chain.nix
       TASTY_NETTEST_IMPORT_SECRET_KEY: "unencrypted:edsk42cYfuawC5i3PmuS3Lq73pAzgrJyVNcv9CXQspM2dG4M9QMpeS"
       TASTY_NETTEST_NODE_ENDPOINT: "http://localhost:8734"
-
-  - label: ligo-test-granadanet-scheduled
-    if: *scheduled
-    <<: *network-tests
-    env:
-      # Note that testnet moneybag can run out of tz. If this happened, someone should transfer it some
-      # more tz, its address: tz1Nbp1gNPMzn9MB9ZhBnfsajsaQBLYScdd5
-      TASTY_NETTEST_IMPORT_SECRET_KEY: "unencrypted:edsk48WyaFHvsqLYQBrCBiRUdnPa7VduZbePo5UAbyMJRN8Eob5PvL"
-      TASTY_NETTEST_NODE_ENDPOINT: "https://granada.testnet.tezos.serokell.team"
 
   - label: ligo-test-hangzhounet-scheduled
     if: *scheduled


### PR DESCRIPTION
## Description

The granada/010 protocol is no longer active on mainnet and its testnet is no longer relevant to us.

This removes the tests on CI based on said protocol

## Related issue(s)

[TM-603](https://issues.serokell.io/issue/TM-603)

## :white_check_mark: Checklist for your Merge Request

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

[//]: # (Add more docs here if you have them in the repository)
- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [Specification](../tree/master/docs/specification.md)
    - [README](../tree/master/README.md)
    - Haddock

#### Stylistic guide (mandatory)

[//]: # (Update link to style guide if necesary or remove if it's not present)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).
